### PR TITLE
StdSchedulerMac: don't call setTolerance:

### DIFF
--- a/src/platform/StdSchedulerMac.mm
+++ b/src/platform/StdSchedulerMac.mm
@@ -218,8 +218,6 @@ static NSMutableDictionary* additionsDictionary;
 	[super registerAt:_additions];
 	auto loop = _additions.runLoop;
 	timer = [NSTimer timerWithTimeInterval:proc->TimerInterval()/1000.0 target:self selector:@selector(run:) userInfo:nil repeats:YES];
-	if ([timer respondsToSelector:@selector(setTolerance:)])
-		[timer setTolerance:0.0];
 	[loop addTimer:timer forMode:NSDefaultRunLoopMode];
 }
 - (void) unregisterFrom:(SCHAdditions*) _additions


### PR DESCRIPTION
respondsToSelector isn't properly guarding against calling this method on unsupported platforms, possibly because it existed as a private method in OS X before 10.9. For example, attempting to build this on OS X 10.8 fails with the error:
```
no visible @interface for 'NSTimer' declares the selector 'setTolerance:'
```

Since the default tolerance is 0 anyway, this can be removed without adverse effect.