### PR TITLE
Use a proplist for optional Sound() arguments

### DIFF
--- a/planet/Objects.ocd/Animals.ocd/PiranhaSmall.ocd/Script.c
+++ b/planet/Objects.ocd/Animals.ocd/PiranhaSmall.ocd/Script.c
@@ -79,7 +79,7 @@ private func UpdateVision()
 
 private func BiteEffect()
 {
-	Sound("Animals::Fish::Munch*", nil, nil, nil, nil, nil, 100);
+	Sound("Animals::Fish::Munch*", {pitch = 100});
 }
 
 local Name = "$Name$";

--- a/planet/Objects.ocd/Animals.ocd/Zaphive.ocd/Zap.ocd/Script.c
+++ b/planet/Objects.ocd/Animals.ocd/Zaphive.ocd/Zap.ocd/Script.c
@@ -170,7 +170,7 @@ private func CheckTurn()
 
 private func AngryBuzz()
 {
-	Sound("Animals::Zap::Zap?", nil,nil,nil,nil, nil, -Random(100));
+	Sound("Animals::Zap::Zap?", {pitch = -Random(100)});
 }
 
 /*-- Saving --*/

--- a/planet/Objects.ocd/Items.ocd/Tools.ocd/Axe.ocd/Script.c
+++ b/planet/Objects.ocd/Items.ocd/Tools.ocd/Axe.ocd/Script.c
@@ -151,7 +151,7 @@ public func ControlUseStart(object clonk, int iX, int iY)
 
 	PlayWeaponAnimation(clonk, animation, 10, Anim_Linear(0, 0, clonk->GetAnimationLength(animation), StrikingLength, ANIM_Remove), Anim_Const(1000));
 	clonk->UpdateAttach();
-	Sound("Objects::Weapons::WeaponSwing?", nil, nil, nil, nil, nil, -Random(10));
+	Sound("Objects::Weapons::WeaponSwing?", {pitch = -Random(10)});
 
 	magic_number=((magic_number+1)%10) + (ObjectNumber()*10);
 	StartWeaponHitCheckEffect(clonk, StrikingLength, 1);

--- a/planet/Objects.ocd/Items.ocd/Tools.ocd/Pickaxe.ocd/Script.c
+++ b/planet/Objects.ocd/Items.ocd/Tools.ocd/Pickaxe.ocd/Script.c
@@ -142,7 +142,7 @@ protected func DoSwing(object clonk, int ix, int iy)
 				spark.OnCollision = PC_Bounce();
 			}
 			CreateParticle("StarSpark", x2*9/10,y2*9/10, PV_Random(-30, 30), PV_Random(-30, 30), PV_Random(10, 50), spark, 30);
-			Sound(sound, nil, nil, nil, nil, nil, pitch);
+			Sound(sound, {pitch = pitch});
 		}
 		
 		// Do blastfree after landscape checks are made. Otherwise, mat always returns as "tunnel"

--- a/planet/Objects.ocd/Items.ocd/Tools.ocd/Sickle.ocd/Script.c
+++ b/planet/Objects.ocd/Items.ocd/Tools.ocd/Sickle.ocd/Script.c
@@ -37,7 +37,7 @@ public func ControlUseStart(object clonk, int x, int y)
 
 	clonk->PlayAnimation(animation, CLONK_ANIM_SLOT_Arms, Anim_Linear(0, 0, clonk->GetAnimationLength(animation), length, ANIM_Remove), Anim_Const(1000));
 	clonk->UpdateAttach();
-	Sound("Objects::Weapons::WeaponSwing?", nil, nil, nil, nil, nil, 100);
+	Sound("Objects::Weapons::WeaponSwing?", {pitch = 100});
 	
 	// Search for harvestable plants
 	var crop = FindObject(Find_AtRect(AbsX(clonk->GetX()-8), AbsY(clonk->GetY()-10), 16,20), Find_NoContainer(), Find_Func("SickleHarvesting"), Find_Func("IsHarvestable"));

--- a/planet/Objects.ocd/Items.ocd/Tools.ocd/WindBag.ocd/Script.c
+++ b/planet/Objects.ocd/Items.ocd/Tools.ocd/WindBag.ocd/Script.c
@@ -87,7 +87,7 @@ public func FxIntReloadTimer(object target, proplist effect, int time)
 	{
 		if (effect.sound)
 		{
-			Sound("Objects::Windbag::Charge", false, nil, nil, -1);
+			Sound("Objects::Windbag::Charge", {loop_count = -1});
 			Sound("Objects::Windbag::ChargeStop");
 			effect.sound = false;
 		}
@@ -104,7 +104,7 @@ public func FxIntReloadTimer(object target, proplist effect, int time)
 	{
 		if (!effect.sound)
 		{
-			Sound("Objects::Windbag::Charge", false, nil, nil, 1);
+			Sound("Objects::Windbag::Charge", {loop_count = 1});
 			effect.sound = true;
 		}
 		
@@ -127,7 +127,7 @@ public func FxIntReloadStop(object target, proplist effect, int reason, bool tem
 		return FX_OK;
 	if (effect.sound)
 	{
-		Sound("Objects::Windbag::Charge", false, nil, nil, -1);	
+		Sound("Objects::Windbag::Charge", {loop_count = -1});
 		Sound("Objects::Windbag::ChargeStop");
 	}
 	return FX_OK;

--- a/planet/Objects.ocd/Items.ocd/Weapons.ocd/Club.ocd/Script.c
+++ b/planet/Objects.ocd/Items.ocd/Weapons.ocd/Club.ocd/Script.c
@@ -117,7 +117,7 @@ public func FinishedAiming(object clonk, int angle)
 	// aaaand, a cooldown
 	AddEffect("ClubWeaponCooldown", clonk, 1, 5, this);
 	
-	Sound("Objects::Weapons::WeaponSwing?", nil, nil, nil, nil, nil, -50);
+	Sound("Objects::Weapons::WeaponSwing?", {pitch = -50});
 	return true;
 }
 
@@ -235,7 +235,7 @@ func DoStrike(clonk, angle)
 	if (found)
 	{
 		RemoveEffect("DuringClubShoot", clonk);
-		Sound("Hits::Materials::Wood::WoodHit?", nil, nil, nil, nil, nil, -10);
+		Sound("Hits::Materials::Wood::WoodHit?", {pitch = -10});
 	}
 }
 

--- a/planet/Objects.ocd/Libraries.ocd/Structures.ocd/Structure.ocd/Script.c
+++ b/planet/Objects.ocd/Libraries.ocd/Structures.ocd/Structure.ocd/Script.c
@@ -315,7 +315,7 @@ public func OnRepairSelected(id symbol, string action, object cursor)
 	if (!hammer)
 	{
 		PlayerMessage(cursor->GetOwner(), "$YouNeedAHammer$");
-		Sound("UI::Click2", nil, nil, cursor->GetOwner());
+		Sound("UI::Click2", {player = cursor->GetOwner()});
 		return;
 	}
 	
@@ -340,7 +340,7 @@ public func OnRepairSelected(id symbol, string action, object cursor)
 	if (total_repair_value == 0)
 	{
 		PlayerMessage(cursor->GetOwner(), "$YouNeedMaterials$");
-		Sound("UI::Click2", nil, nil, cursor->GetOwner());
+		Sound("UI::Click2", {player = cursor->GetOwner()});
 		return;
 	}
 	

--- a/planet/Objects.ocd/Libraries.ocd/Structures.ocd/Vendor.ocd/Script.c
+++ b/planet/Objects.ocd/Libraries.ocd/Structures.ocd/Vendor.ocd/Script.c
@@ -80,14 +80,14 @@ func DoBuy(id item, int for_player, int wealth_player, object buyer, bool buy_al
 		{
 			if(show_errors)
 			{
-				Sound("UI::Error", nil, nil, for_player + 1);
+				Sound("UI::Error", {player = for_player + 1});
 				PlayerMessage(for_player, "$MsgNotEnoughWealth$");
 			}
 			break;
 		}
 		// Take the cash
 		DoWealth(wealth_player, -price);
-		Sound("UI::UnCash", nil, nil, for_player + 1); // TODO: get sound
+		Sound("UI::UnCash", {player = for_player + 1}); // TODO: get sound
 		// Decrease the base material, allow runtime overload
 		this->ChangeBuyableAmount(wealth_player, item, -1);
 		// Deliver the object
@@ -113,7 +113,7 @@ func DoSell(object obj, int wealth_player)
 
 	// Give the player the cash
 	DoWealth(wealth_player, this->GetSellValue(obj));
-	Sound("UI::Cash", nil, nil, wealth_player + 1);
+	Sound("UI::Cash", {player = wealth_player + 1});
 
 	// OnSale callback to object e.g. for goal updates
 	obj->~OnSale(wealth_player, this);

--- a/planet/Objects.ocd/Structures.ocd/ChemicalLab.ocd/Script.c
+++ b/planet/Objects.ocd/Structures.ocd/ChemicalLab.ocd/Script.c
@@ -29,26 +29,26 @@ public func OnProductionStart(id product)
 {
 	AddEffect("Working", this, 100, 1, this);
 	hold_production = false;
-	Sound("Liquids::Boiling", false, nil, nil, 1);
+	Sound("Liquids::Boiling", {loop_count = 1});
 }
 
 public func OnProductionHold(id product)
 {
 	hold_production = true;
-	Sound("Liquids::Boiling", false, nil, nil, -1);
+	Sound("Liquids::Boiling", {loop_count = -1});
 	Sound("Fire::Blowout");
 }
 
 public func OnProductionContinued(id product)
 {
 	hold_production = false;
-	Sound("Liquids::Boiling", false, nil, nil, 1);
+	Sound("Liquids::Boiling", {loop_count = 1});
 }
 
 public func OnProductionFinish(id product)
 {
 	RemoveEffect("Working", this);
-	Sound("Liquids::Boiling", false, nil, nil, -1);
+	Sound("Liquids::Boiling", {loop_count = -1});
 }
 
 protected func FxWorkingTimer()

--- a/planet/Objects.ocd/Structures.ocd/Elevator.ocd/Case.ocd/Script.c
+++ b/planet/Objects.ocd/Structures.ocd/Elevator.ocd/Case.ocd/Script.c
@@ -639,7 +639,7 @@ public func ControlUseStart(object clonk, int x, int y)
 	if (IsSlave()) 
 		return Control2Master("ControlUseStart", clonk, x, y);
 	MoveTo(GetY() + y, 0, nil, true);
-	Sound("UI::Click", nil, nil, clonk->GetOwner());
+	Sound("UI::Click", {player = clonk->GetOwner()});
 	// Do not trigger a UseStop-callback.
 	return false;
 }
@@ -669,7 +669,7 @@ public func ControlUp(object clonk)
 	// what is that player even doing
 	if (GetY() <= elevator->GetY() + 20)
 	{
-		Sound("UI::Click", nil, nil, clonk->GetOwner());
+		Sound("UI::Click", {player = clonk->GetOwner()});
 		return true;
 	}
 	

--- a/planet/Objects.ocd/Structures.ocd/Elevator.ocd/Script.c
+++ b/planet/Objects.ocd/Structures.ocd/Elevator.ocd/Script.c
@@ -144,7 +144,7 @@ public func StartEngine(int direction, bool silent)
 
 	if (!silent)
 	{
-		Sound("Structures::Elevator::Start", nil, nil, nil, nil, 400);
+		Sound("Structures::Elevator::Start", {custom_falloff_distance = 400});
 		ScheduleCall(this, "EngineLoop", 34);
 	}
 	if (wheel_anim == nil) // If for some reason the animation has stopped
@@ -169,16 +169,16 @@ public func StartEngine(int direction, bool silent)
 
 public func EngineLoop()
 {
-	Sound("Structures::Elevator::Moving", nil, nil, nil, 1, 400);
+	Sound("Structures::Elevator::Moving", {loop_count = 1, custom_falloff_distance = 400});
 }
 
 public func StopEngine(bool silent)
 {
 	if (!silent)
 	{
-		Sound("Structures::Elevator::Moving", nil, nil, nil, -1);
+		Sound("Structures::Elevator::Moving", {loop_count = -1});
 		ClearScheduleCall(this, "EngineLoop");
-		Sound("Structures::Elevator::Stop", nil, nil, nil, nil, 400);
+		Sound("Structures::Elevator::Stop", {custom_falloff_distance = 400});
 	}
 
 	if (wheel_anim == nil) return;

--- a/planet/Objects.ocd/Structures.ocd/Sawmill.ocd/Script.c
+++ b/planet/Objects.ocd/Structures.ocd/Sawmill.ocd/Script.c
@@ -244,8 +244,8 @@ private func SpinOn(int diff)
 		rotate = 0;
 		SetMeshMaterial("SawmillBlade.Spin", 2);
 		running = true;
-		Sound("Structures::SawmillRipcut", nil, nil, nil, +1);
-		Sound("Sawmill::EngineLoop", nil, nil, nil, +1);
+		Sound("Structures::SawmillRipcut", {loop_count = +1});
+		Sound("Sawmill::EngineLoop", {loop_count = +1});
 	}
 
 	SetProperty("MeshTransformation", Trans_Mul(Trans_Rotate(-20, 0, 1, 0), Trans_Rotate(rotate, 1, 0, 0)));
@@ -260,14 +260,14 @@ private func SpinOff(int call)
 		running = false;
 		spin = 50;
 		SetMeshMaterial("SawmillBlade", 2);
-		Sound("Structures::SawmillRipcut", nil, nil, nil, -1);
+		Sound("Structures::SawmillRipcut", {loop_count = -1});
 		SetProperty("MeshTransformation", Trans_Rotate(-20, 0, 1, 0));
 	}
 	if (call == 1) spin = 75;
 	if (call == 2)
 	{
 		spin = 100;
-		Sound("Sawmill::EngineLoop", nil, nil, nil, -1);
+		Sound("Sawmill::EngineLoop", {loop_count = -1});
 		Sound("Sawmill::EngineStop");
 	}
 	if (call == 3) spin = 150;

--- a/planet/Objects.ocd/Structures.ocd/SteamEngine.ocd/Script.c
+++ b/planet/Objects.ocd/Structures.ocd/SteamEngine.ocd/Script.c
@@ -112,7 +112,7 @@ public func OnPowerProductionStop(int amount)
 // Start call from working action.
 protected func WorkStart()
 {
-	Sound("Structures::SteamEngine", false, nil, nil, 1);
+	Sound("Structures::SteamEngine", {loop_count = 1});
 	return;
 }
 
@@ -155,7 +155,7 @@ protected func WorkStop()
 protected func WorkAbort()
 {
 	// Sound can be safely stopped here since this action will always end with an abort call.
-	Sound("Structures::SteamEngine", false, nil, nil, -1);
+	Sound("Structures::SteamEngine", {loop_count = -1});
 	return;	
 }
 

--- a/planet/Objects.ocd/Structures.ocd/WindGenerator.ocd/Script.c
+++ b/planet/Objects.ocd/Structures.ocd/WindGenerator.ocd/Script.c
@@ -116,7 +116,7 @@ public func Wind2Turn()
 	wheel->SetRDir(current_wind * 90, MinRevolutionTime());
 	// Make some sounds.
 	if (Abs(current_wind) >= 10 && Random(15 - Abs(current_wind / 10)) < 5)
-		Sound(["Hits::Materials::Wood::WoodCreak?","Structures::HingeCreak?"][Random(2)], false, nil, nil, nil, 75);
+		Sound(["Hits::Materials::Wood::WoodCreak?","Structures::HingeCreak?"][Random(2)], {custom_falloff_distance = 75});
 	return;
 }
 

--- a/planet/Objects.ocd/Vehicles.ocd/Airship.ocd/Script.c
+++ b/planet/Objects.ocd/Vehicles.ocd/Airship.ocd/Script.c
@@ -113,7 +113,7 @@ public func FxIntAirshipMovementTimer(object target, proplist effect, int time)
 		{
 			// Fade pitch from -45 to 0
 			enginesound += 5;
-			Sound("Structures::FanLoop",nil,nil,nil, 1, 0, enginesound - 50);
+			Sound("Structures::FanLoop", {loop_count = 1, pitch = enginesound - 50});
 		}
 	}
 	else if(enginesound)
@@ -121,9 +121,9 @@ public func FxIntAirshipMovementTimer(object target, proplist effect, int time)
 		// Fade pitch from 0 to minimum -45, then turn off
 		enginesound = Max(enginesound - 10);
 		if (enginesound)
-			Sound("Structures::FanLoop", nil, nil, nil, 1, 0, enginesound - 50);
+			Sound("Structures::FanLoop", {loop_count = 1, pitch = enginesound - 50});
 		else
-			Sound("Structures::FanLoop", nil, nil, nil, -1);
+			Sound("Structures::FanLoop", {loop_count = -1});
 	}
 
 	// Wind movement if in the air

--- a/planet/Objects.ocd/Vehicles.ocd/Lorry.ocd/Script.c
+++ b/planet/Objects.ocd/Vehicles.ocd/Lorry.ocd/Script.c
@@ -220,12 +220,12 @@ public func TurnWheels()
 	if (Abs(GetXDir()) > 1 && !wheel_sound)
 	{
 		if (!wheel_sound) 
-			Sound("Structures::WheelsTurn", false, nil, nil, 1);
+			Sound("Structures::WheelsTurn", {loop_count = 1});
 		wheel_sound = true;
 	}
 	else if (wheel_sound && !GetXDir())
 	{
-		Sound("Structures::WheelsTurn", false, nil, nil, -1);
+		Sound("Structures::WheelsTurn", {loop_count = -1});
 		wheel_sound = false;
 	}
 }

--- a/planet/System.ocg/NamedParams.c
+++ b/planet/System.ocg/NamedParams.c
@@ -1,0 +1,21 @@
+/*--
+		NamedParams.c
+
+		Adapts some functions with lots of optional parameters to take a proplist instead.
+--*/
+
+global func Sound(string name, opts, ...)
+{
+	if (GetType(opts) == C4V_PropList)
+		return inherited(name, opts.global, opts.volume, opts.player, opts.loop_count, opts.custom_falloff_distance, opts.pitch, opts.modifier);
+	else
+		return inherited(name, opts, ...);
+}
+
+global func SoundAt(string name, int x, int y, opts, ...)
+{
+	if (GetType(opts) == C4V_PropList)
+		return inherited(name, x, y, opts.volume, opts.player, opts.custom_falloff_distance, opts.pitch, opts.modifier);
+	else
+		return inherited(name, x, y, opts, ...);
+}


### PR DESCRIPTION
Sound() has a lot of optional arguments which can be used independently. Most of the time, only a single one of these is needed, resulting in [oddly-looking code](http://docs.openclonk.org/en/sdk/script/SoundModifiers.html).

With this patch, a proplist can be passed instead, simulating named arguments. This pattern is common in other languages such as Ruby and JavaScript.

I also replaced some usages of Sound() with the new variant.