### PR TITLE
Implement mouse grabbing for GTK on X11 (#1637)

### DIFF
--- a/src/platform/C4Window.h
+++ b/src/platform/C4Window.h
@@ -430,6 +430,8 @@ public:
 	// Set by Init to the widget which is used as a
 	// render target, which can be the whole window.
 	/*GtkWidget*/void * render_widget;
+	// Mouse grabbing has to be restored when the window gains focus.
+	bool mouse_was_grabbed = false;
 #elif defined(USE_SDL_MAINLOOP)
 	SDL_Window * window;
 #endif


### PR DESCRIPTION
The same thing should somehow also be possible using gdk_device_grab(), but I couldn't get it to work properly.

The pure GTK code would look something like this (without focus handling):

```cpp
void C4Window::GrabMouse(bool grab)
{
    GdkWindow *gdkwindow = gtk_widget_get_window(GTK_WIDGET(window));
    GdkDeviceManager *device_manager = gdk_display_get_device_manager(gdk_display_get_default());
    if (!device_manager) return;
    GdkDevice *pointer = gdk_device_manager_get_client_pointer(device_manager);
    if (grab)
    {
        gdk_device_grab(pointer, gdkwindow, GDK_OWNERSHIP_NONE, true, GDK_ALL_EVENTS_MASK, NULL, GDK_CURRENT_TIME);
    }
    else
    {
        gdk_device_ungrab(pointer, GDK_CURRENT_TIME);
    }
}
```

This wouldn't allow you to click outside the window, but the mouse cursor gets stuck when nearing the edge of the game window.