### PR TITLE
Make memory allocation/deallocation more consistent

### DIFF
--- a/src/lib/StdCompiler.cpp
+++ b/src/lib/StdCompiler.cpp
@@ -148,7 +148,7 @@ void StdCompilerBinRead::String(char **pszString, RawCompileType eType)
 		if (iPos >= Buf.getSize())
 			{ excEOF(); return; }
 	// Allocate and copy data
-	*pszString = new char [iPos - iStart];
+	*pszString = (char *) malloc(iPos - iStart);
 	memcpy(*pszString, Buf.getPtr(iStart), iPos - iStart);
 }
 

--- a/src/network/C4Network2Res.cpp
+++ b/src/network/C4Network2Res.cpp
@@ -1215,7 +1215,7 @@ bool C4Network2ResChunk::Set(C4Network2Res *pRes, uint32_t inChunk)
 		if (lseek(f, iOffset, SEEK_SET) != iOffset)
 			{ close(f); LogF("Network: could not read resource file %s!", pRes->getFile()); return false; }
 	// read chunk of data
-	char *pBuf = new char[iSize];
+	char *pBuf = (char *) malloc(iSize);
 	if (read(f, pBuf, iSize) != iSize)
 		{ delete [] pBuf; close(f); LogF("Network: could not read resource file %s!", pRes->getFile()); return false; }
 	// set

--- a/src/network/C4Network2Res.cpp
+++ b/src/network/C4Network2Res.cpp
@@ -1217,7 +1217,7 @@ bool C4Network2ResChunk::Set(C4Network2Res *pRes, uint32_t inChunk)
 	// read chunk of data
 	char *pBuf = (char *) malloc(iSize);
 	if (read(f, pBuf, iSize) != iSize)
-		{ delete [] pBuf; close(f); LogF("Network: could not read resource file %s!", pRes->getFile()); return false; }
+		{ free(pBuf); close(f); LogF("Network: could not read resource file %s!", pRes->getFile()); return false; }
 	// set
 	Data.Take(pBuf, iSize);
 	// close


### PR DESCRIPTION
valgrind was complaining about the use of `free` to deallocate memory allocated with `new` rather than `malloc`. Fixed this.