### PR TITLE
Add OpenClonk to StrategyGame and ArcadeGame categories.

### DIFF
--- a/openclonk.desktop
+++ b/openclonk.desktop
@@ -6,6 +6,6 @@ Comment[de]=Ein actiongeladenes Taktikspiel.
 GenericName=Multiplayer action, tactics and skill game
 Icon=openclonk
 Exec=openclonk
-Categories=Game;ActionGame;
+Categories=Game;ActionGame;StrategyGame;ArcadeGame;
 StartupNotify=true
 MimeType=x-scheme-handler/clonk;


### PR DESCRIPTION
[Debian bug #825678](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=825678) suggested to modify OpenClonk's desktop file to add it to the StrategyGame and ArcadeGame categories to aid discoverability. Strategy sort of fits considering that it contains real-time strategy levels. Arcade seemed borderline but also felt true given that the tutorial and some other levels might be considered arcade.