### PR TITLE
Appveyor integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(Version)
 
-set(CMAKE_ADDITIONAL_DEPS_PATH "${CMAKE_CURRENT_BINARY_DIR}/deps" CACHE PATH "Additional directory to search for libraries and headers")
+set(CMAKE_ADDITIONAL_DEPS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/deps" CACHE PATH "Additional directory to search for libraries and headers")
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_ADDITIONAL_DEPS_PATH})
 
 ############################################################################

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,20 +11,11 @@ branches:
 configuration:
   - RelWithDebInfo
 
-environment:
-  matrix:
-    - CMAKE_GENERATOR_PREFIX: Visual Studio 14 2015
-
 platform:
   - Win32
-  - x64
 
 before_build:
-  - if "%platform%" == "x64" (
-      set CMAKE_GENERATOR=%CMAKE_GENERATOR_PREFIX% Win64
-    ) else (
-      set CMAKE_GENERATOR=%CMAKE_GENERATOR_PREFIX%
-    )
+  - set BUILD_DIR=%APPVEYOR_BUILD_FOLDER%\build
   # Based on http://stackoverflow.com/a/39408964
   - set PREFIX=%APPVEYOR_BUILD_FOLDER%\deps
   - if exist %PREFIX% set NEEDDEPS=rem
@@ -33,23 +24,24 @@ before_build:
     %NEEDDEPS% cd thirdparty
     %NEEDDEPS% mkdir build
     %NEEDDEPS% cd build
-    %NEEDDEPS% cmake .. -G"%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=%PREFIX%
+    %NEEDDEPS% cmake .. -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=%PREFIX%
     %NEEDDEPS% cmake --build . --config %configuration% -- /m
 
-  - 7z a dep-libs.zip %APPVEYOR_BUILD_FOLDER%\deps\bin\*.dll
   - |-
-    cd %APPVEYOR_BUILD_FOLDER%
-    cmake . -G"%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=%configuration%
+    mkdir %BUILD_DIR%
+    cd %BUILD_DIR%
+    cmake %APPVEYOR_BUILD_FOLDER% -DCMAKE_BUILD_TYPE=%configuration%
+
+# The following enables c4group.exe to run on the build machine, and makes the installed openclonk usable
+  - for %%F in (zlib.dll,glew32.dll,libpng16.dll,OpenAL32.dll,alut.dll) do (copy /Y %PREFIX%\bin\%%F %BUILD_DIR%)
 
 build:
   parallel: true
-  project: openclonk.sln
+  project: build/setup.vcxproj
   verbosity: minimal
 
 cache:
   - deps -> thirdparty\CMakeLists.txt
 
 artifacts:
-  - path: setup_openclonk.exe
-  - path: openclonk.exe
-  - path: dep-libs.zip
+  - path: build\setup_openclonk.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,55 @@
+# can use variables like {build} and {branch}
+version: 1.0.{build}-{branch}
+pull_requests:
+  do_not_increment_build_number: true
+
+branches:
+  only:
+    - appveyor
+    - master
+
+configuration:
+  - RelWithDebInfo
+
+environment:
+  matrix:
+    - CMAKE_GENERATOR_PREFIX: Visual Studio 14 2015
+
+platform:
+  - Win32
+  - x64
+
+before_build:
+  - if "%platform%" == "x64" (
+      set CMAKE_GENERATOR=%CMAKE_GENERATOR_PREFIX% Win64
+    ) else (
+      set CMAKE_GENERATOR=%CMAKE_GENERATOR_PREFIX%
+    )
+  # Based on http://stackoverflow.com/a/39408964
+  - set PREFIX=%APPVEYOR_BUILD_FOLDER%\deps
+  - if exist %PREFIX% set NEEDDEPS=rem
+  # Depends
+  - |-
+    %NEEDDEPS% cd thirdparty
+    %NEEDDEPS% mkdir build
+    %NEEDDEPS% cd build
+    %NEEDDEPS% cmake .. -G"%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=%PREFIX%
+    %NEEDDEPS% cmake --build . --config %configuration% -- /m
+
+  - 7z a dep-libs.zip %APPVEYOR_BUILD_FOLDER%\deps\bin\*.dll
+  - |-
+    cd %APPVEYOR_BUILD_FOLDER%
+    cmake . -G"%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=%configuration%
+
+build:
+  parallel: true
+  project: openclonk.sln
+  verbosity: minimal
+
+cache:
+  - deps -> thirdparty\CMakeLists.txt
+
+artifacts:
+  - path: setup_openclonk.exe
+  - path: openclonk.exe
+  - path: dep-libs.zip

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required (VERSION 3.0)
+
+if (NOT WIN32)
+  message("This file builds third-party dependencies of openclonk only on Windows")
+  # For other platforms please use the respective package managers
+  return()
+endif()
+
+include(ExternalProject)
+
+ExternalProject_Add(freetype2
+  GIT_REPOSITORY "git://git.savannah.gnu.org/freetype/freetype2.git"
+  GIT_TAG "VER-2-7-1"
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+             -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+)
+
+ExternalProject_Add(nasm
+  URL "http://www.nasm.us/pub/nasm/releasebuilds/2.12.02/win32/nasm-2.12.02-win32.zip"
+  URL_HASH SHA256=91b9f784b1286e3de73dabfdc7466c198b96fef7080e00710411119959935809
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/nasm"
+  INSTALL_COMMAND ""
+)
+
+ExternalProject_Add("libjpeg-turbo"
+  DEPENDS nasm
+  GIT_REPOSITORY "git://github.com/libjpeg-turbo/libjpeg-turbo.git"
+  GIT_TAG "1.5.1"
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+             -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+             -DNASM:FILEPATH=${CMAKE_CURRENT_BINARY_DIR}/nasm/nasm
+)
+
+ExternalProject_Add(zlib
+  GIT_REPOSITORY "git://github.com/madler/zlib.git"
+  GIT_TAG "v1.2.11"
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+             -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+)
+
+ExternalProject_Add(libpng
+  DEPENDS zlib
+  GIT_REPOSITORY "git://github.com/glennrp/libpng.git"
+  GIT_TAG "v1.6.29"
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+             -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+)
+
+ExternalProject_Add(glew
+  URL "https://github.com/nigels-com/glew/releases/download/glew-2.0.0/glew-2.0.0-win32.zip"
+  URL_HASH SHA256=9c1d00b550df96899dde289cdebfb5eba5b1ae14853ec41eb905c85106fbd3ae
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  BUILD_IN_SOURCE 1
+  INSTALL_COMMAND ${CMAKE_COMMAND} "-DINSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}" -P "${CMAKE_CURRENT_SOURCE_DIR}/InstallGLEW.cmake"
+)
+
+ExternalProject_Add(OpenAL
+  GIT_REPOSITORY "git://github.com/kcat/openal-soft.git"
+  GIT_TAG "openal-soft-1.17.2"
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+             -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+)
+
+find_package(Git REQUIRED)
+ExternalProject_Add(FreeALUT
+  DEPENDS OpenAL
+  GIT_REPOSITORY "git://github.com/vancegroup/freealut.git"
+  GIT_TAG "freealut_1_1_0"
+  PATCH_COMMAND ${GIT_EXECUTABLE} apply ${CMAKE_CURRENT_SOURCE_DIR}/FreeALUT.patch
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+             -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+             -DOPENAL_LIB_DIR=${CMAKE_INSTALL_PREFIX}/lib
+             -DOPENAL_INCLUDE_DIR=${CMAKE_INSTALL_PREFIX}/include
+)
+
+ExternalProject_Add(Ogg
+  GIT_REPOSITORY "git://github.com/xiph/ogg.git"
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+             -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+)
+
+ExternalProject_Add(Vorbis
+  GIT_REPOSITORY "git://github.com/xiph/vorbis.git"
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+             -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+)

--- a/thirdparty/FreeALUT.patch
+++ b/thirdparty/FreeALUT.patch
@@ -1,0 +1,16 @@
+diff --git a/include/AL/alut.h b/include/AL/alut.h
+index 4b05a3c..6d0889a 100644
+--- a/include/AL/alut.h
++++ b/include/AL/alut.h
+@@ -1,10 +1,7 @@
+ #if !defined(AL_ALUT_H)
+ #define AL_ALUT_H
+ 
+-#if defined(_MSC_VER)
+-#include <alc.h>
+-#include <al.h>
+-#elif defined(__APPLE__)
++#if defined(__APPLE__)
+ #include <OpenAL/alc.h>
+ #include <OpenAL/al.h>
+ #else

--- a/thirdparty/InstallGLEW.cmake
+++ b/thirdparty/InstallGLEW.cmake
@@ -1,0 +1,18 @@
+#!/usr/bin/env cmake -P
+
+# The pre-built glew binaries for Windows are extracted in a different
+# location from where FindGLEW.cmake expects them. This script copies
+# them to the right location.
+
+if(NOT WIN32)
+  message(FATAL_ERROR "This script is useful only for Windows. Please use the native package manager or the source build for other platforms")
+endif()
+
+# set PLATFORM=x64 to use the 64-bit binaries instead of the default 32-bit
+if(NOT DEFINED ENV{PLATFORM})
+  set(ENV{PLATFORM} Win32)
+endif()
+
+file(COPY "bin/Release/$ENV{PLATFORM}/glew32.dll" DESTINATION "${INSTALL_PREFIX}/bin")
+file(COPY "include/GL" DESTINATION "${INSTALL_PREFIX}/include")
+file(COPY "lib/Release/$ENV{PLATFORM}/glew32.lib" DESTINATION "${INSTALL_PREFIX}/lib")


### PR DESCRIPTION
The PR does the following:
- Build/install the required thirdparty dependencies - as mentioned in [README](..#readme).
  - Cache the built dependencies to improve the subsequent builds' performance.
- Build openclonk (setup) and upload it as an artifact.

The only change to existing code is one line in [CMakeLists.txt](#diff-af3b638bc2a3e6c650974192a53c7291) to simplify the out-of-tree build in AppVeyor. This doesn't affect the Travis CI builds as those are built in-tree.

Note that the [thirdparty/CMakeLists.txt](#diff-473f2985d91d820c1be94e0218e3d22fR3) only builds/installs the dependencies on Windows for now. On other platforms, it prints a helpful message and returns. This can be revisited when the references to `nasm` and `glew` are addressed. The rest of the projects can build on all platforms (the CMake way).

Other files:
- FreeALUT.patch: patch `alut.h` to use the OpenAL headers on Windows the same way as other non-Apple platforms (presumably Linux, BSDs, etc.).
- InstallGLEW.cmake: to copy the GLEW binaries from their extracted location to where FindGLEW.cmake expects them.

A sample build (using cached dependencies) is [here](https://ci.appveyor.com/project/tusharpm/openclonk/build/1.0.21-appveyor). The setup can be downloaded from [the build artifacts page](https://ci.appveyor.com/project/tusharpm/openclonk/build/1.0.21-appveyor/artifacts).

TODO (can be addressed after this is merged):
- The AppVeyor hooks on GitHub needs to be enabled manually.
- Add the AppVeyor status badge (looks like the Travis badge is missing as well) - optional.
- Sign the binaries if required for deployment.