### PR TITLE
Cmake updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-4.9', 'build-essential', 'cmake', 'libfreetype6-dev', 'libgl1-mesa-dev', 'libglew-dev', 'libgtk-3-dev', 'libjpeg-dev', 'libpng-dev', 'libsdl2-dev', 'libupnp-dev', 'libxrandr-dev', 'x11proto-core-dev', 'zlib1g-dev', 'libalut0', 'libgtest-dev']
+          packages: ['g++-4.9', 'build-essential', 'cmake', 'libfreetype6-dev', 'libgl1-mesa-dev', 'libglew-dev', 'libgtk-3-dev', 'libjpeg-dev', 'libpng-dev', 'libsdl2-dev', 'libupnp-dev', 'libxrandr-dev', 'x11proto-core-dev', 'zlib1g-dev', 'libalut0']
       env: 
           - CCOMPILER=gcc-4.9 
           - CXXCOMPILER=g++-4.9 
@@ -23,7 +23,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-5', 'build-essential', 'cmake', 'libfreetype6-dev', 'libgl1-mesa-dev', 'libglew-dev', 'libgtk-3-dev', 'libjpeg-dev', 'libpng-dev', 'libsdl2-dev', 'libupnp-dev', 'libxrandr-dev', 'x11proto-core-dev', 'zlib1g-dev', 'libalut0', 'ninja-build', 'libgtest-dev']
+          packages: ['g++-5', 'build-essential', 'cmake', 'libfreetype6-dev', 'libgl1-mesa-dev', 'libglew-dev', 'libgtk-3-dev', 'libjpeg-dev', 'libpng-dev', 'libsdl2-dev', 'libupnp-dev', 'libxrandr-dev', 'x11proto-core-dev', 'zlib1g-dev', 'libalut0', 'ninja-build']
       env:
           - CCOMPILER=gcc-5
           - CXXCOMPILER=g++-5
@@ -36,16 +36,13 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8']
-          packages: ['clang-3.8', 'build-essential', 'cmake', 'libfreetype6-dev', 'libgl1-mesa-dev', 'libglew-dev', 'libgtk-3-dev', 'libjpeg-dev', 'libpng-dev', 'libsdl2-dev', 'libupnp-dev', 'libxrandr-dev', 'x11proto-core-dev', 'zlib1g-dev', 'libalut0', 'ninja-build', 'libc++-dev', 'libc++1', 'libgtest-dev']
+          packages: ['clang-3.8', 'build-essential', 'cmake', 'libfreetype6-dev', 'libgl1-mesa-dev', 'libglew-dev', 'libgtk-3-dev', 'libjpeg-dev', 'libpng-dev', 'libsdl2-dev', 'libupnp-dev', 'libxrandr-dev', 'x11proto-core-dev', 'zlib1g-dev', 'libalut0', 'ninja-build', 'libc++-dev', 'libc++1']
       env: 
           - CCOMPILER=clang-3.8 
           - CXXCOMPILER=clang++-3.8 
           - CXX_FLAGS="-stdlib=libc++ -fcolor-diagnostics" 
           - TYPE=Debug 
           - BSYS="Ninja#ninja -k30"
-
-before_install:
-    - for t in test mock; do wget https://github.com/google/google$t/archive/release-1.7.0.tar.gz -Og$t.tgz && tar xvf g$t.tgz; done 
 
 before_script:
     - export CXX="$CXXCOMPILER" CC="$CCOMPILER"
@@ -55,11 +52,8 @@ before_script:
       -DCMAKE_BUILD_TYPE="$TYPE"
       -DCMAKE_CXX_FLAGS="$CXX_FLAGS"
       -DUSE_GCC_PCH=${PCH:-off}
-      -DGTEST_ROOT=$PWD/googletest-release-1.7.0
-      -DGMOCK_ROOT=$PWD/googlemock-release-1.7.0
       .
 
 script:
-    - ${BSYS/*#/} all netpuncher tests aul_test
-    - ./tests/tests 
-    - ./tests/aul_test
+    - ${BSYS/*#/} all netpuncher
+    - ctest -C $TYPE --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1367,7 +1367,10 @@ endif()
 ############################################################################
 # Miscellaneous
 ############################################################################
-add_subdirectory(tests)
+include(CTest)
+if(BUILD_TESTING)
+	add_subdirectory(tests)
+endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 

--- a/cmake/DownloadProject.CMakeLists.txt.in
+++ b/cmake/DownloadProject.CMakeLists.txt.in
@@ -1,0 +1,21 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+#========================================================================================
+#
+# Modified by tusharpm for openclonk.
+#
+
+cmake_minimum_required(VERSION 2.8.2)
+
+project(@DL_ARGS_PROJ@-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(@DL_ARGS_PROJ@-download
+                    @DL_ARGS_UNPARSED_ARGUMENTS@
+                    SOURCE_DIR          @DL_ARGS_SOURCE_DIR@
+                    BINARY_DIR          @DL_ARGS_BINARY_DIR@
+                    CONFIGURE_COMMAND   ""
+                    BUILD_COMMAND       ""
+                    INSTALL_COMMAND     ""
+                    TEST_COMMAND        ""
+)

--- a/cmake/DownloadProject.cmake
+++ b/cmake/DownloadProject.cmake
@@ -1,0 +1,184 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+#
+# MODULE:   DownloadProject
+#
+# PROVIDES:
+#   download_project( PROJ projectName
+#                    [PREFIX prefixDir]
+#                    [DOWNLOAD_DIR downloadDir]
+#                    [SOURCE_DIR srcDir]
+#                    [BINARY_DIR binDir]
+#                    [QUIET]
+#                    ...
+#   )
+#
+#       Provides the ability to download and unpack a tarball, zip file, git repository,
+#       etc. at configure time (i.e. when the cmake command is run). How the downloaded
+#       and unpacked contents are used is up to the caller, but the motivating case is
+#       to download source code which can then be included directly in the build with
+#       add_subdirectory() after the call to download_project(). Source and build
+#       directories are set up with this in mind.
+#
+#       The PROJ argument is required. The projectName value will be used to construct
+#       the following variables upon exit (obviously replace projectName with its actual
+#       value):
+#
+#           projectName_SOURCE_DIR
+#           projectName_BINARY_DIR
+#
+#       The SOURCE_DIR and BINARY_DIR arguments are optional and would not typically
+#       need to be provided. They can be specified if you want the downloaded source
+#       and build directories to be located in a specific place. The contents of
+#       projectName_SOURCE_DIR and projectName_BINARY_DIR will be populated with the
+#       locations used whether you provide SOURCE_DIR/BINARY_DIR or not.
+#
+#       The DOWNLOAD_DIR argument does not normally need to be set. It controls the
+#       location of the temporary CMake build used to perform the download.
+#
+#       The PREFIX argument can be provided to change the base location of the default
+#       values of DOWNLOAD_DIR, SOURCE_DIR and BINARY_DIR. If all of those three arguments
+#       are provided, then PREFIX will have no effect. The default value for PREFIX is
+#       CMAKE_BINARY_DIR.
+#
+#       The QUIET option can be given if you do not want to show the output associated
+#       with downloading the specified project.
+#
+#       In addition to the above, any other options are passed through unmodified to
+#       ExternalProject_Add() to perform the actual download, patch and update steps.
+#       The following ExternalProject_Add() options are explicitly prohibited (they
+#       are reserved for use by the download_project() command):
+#
+#           CONFIGURE_COMMAND
+#           BUILD_COMMAND
+#           INSTALL_COMMAND
+#           TEST_COMMAND
+#
+#       Only those ExternalProject_Add() arguments which relate to downloading, patching
+#       and updating of the project sources are intended to be used. Also note that at
+#       least one set of download-related arguments are required.
+#
+#       If using CMake 3.2 or later, the UPDATE_DISCONNECTED option can be used to
+#       prevent a check at the remote end for changes every time CMake is run
+#       after the first successful download. See the documentation of the ExternalProject
+#       module for more information. It is likely you will want to use this option if it
+#       is available to you. Note, however, that the ExternalProject implementation contains
+#       bugs which result in incorrect handling of the UPDATE_DISCONNECTED option when
+#       using the URL download method or when specifying a SOURCE_DIR with no download
+#       method. Fixes for these have been created, the last of which is scheduled for
+#       inclusion in CMake 3.8.0. Details can be found here:
+#
+#           https://gitlab.kitware.com/cmake/cmake/commit/bdca68388bd57f8302d3c1d83d691034b7ffa70c
+#           https://gitlab.kitware.com/cmake/cmake/issues/16428
+#
+#       If you experience build errors related to the update step, consider avoiding
+#       the use of UPDATE_DISCONNECTED.
+#
+# EXAMPLE USAGE:
+#
+#   include(DownloadProject)
+#   download_project(PROJ                googletest
+#                    GIT_REPOSITORY      https://github.com/google/googletest.git
+#                    GIT_TAG             master
+#                    UPDATE_DISCONNECTED 1
+#                    QUIET
+#   )
+#
+#   add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+#
+#========================================================================================
+#
+# Modified by tusharpm for openclonk.
+#
+
+
+set(_DownloadProjectDir "${CMAKE_CURRENT_LIST_DIR}")
+
+include(CMakeParseArguments)
+
+function(download_project)
+
+    set(options QUIET)
+    set(oneValueArgs
+        PROJ
+        PREFIX
+        DOWNLOAD_DIR
+        SOURCE_DIR
+        BINARY_DIR
+        # Prevent the following from being passed through
+        CONFIGURE_COMMAND
+        BUILD_COMMAND
+        INSTALL_COMMAND
+        TEST_COMMAND
+    )
+    set(multiValueArgs "")
+
+    cmake_parse_arguments(DL_ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Hide output if requested
+    if (DL_ARGS_QUIET)
+        set(OUTPUT_QUIET "OUTPUT_QUIET")
+    else()
+        unset(OUTPUT_QUIET)
+        message(STATUS "Downloading/updating ${DL_ARGS_PROJ}")
+    endif()
+
+    # Set up where we will put our temporary CMakeLists.txt file and also
+    # the base point below which the default source and binary dirs will be.
+    # The prefix must always be an absolute path.
+    if (NOT DL_ARGS_PREFIX)
+        set(DL_ARGS_PREFIX "${CMAKE_BINARY_DIR}")
+    else()
+        get_filename_component(DL_ARGS_PREFIX "${DL_ARGS_PREFIX}" ABSOLUTE
+                               BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+    endif()
+    if (NOT DL_ARGS_DOWNLOAD_DIR)
+        set(DL_ARGS_DOWNLOAD_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-download")
+    endif()
+
+    # Ensure the caller can know where to find the source and build directories
+    if (NOT DL_ARGS_SOURCE_DIR)
+        set(DL_ARGS_SOURCE_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-src")
+    endif()
+    if (NOT DL_ARGS_BINARY_DIR)
+        set(DL_ARGS_BINARY_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-build")
+    endif()
+    set(${DL_ARGS_PROJ}_SOURCE_DIR "${DL_ARGS_SOURCE_DIR}" PARENT_SCOPE)
+    set(${DL_ARGS_PROJ}_BINARY_DIR "${DL_ARGS_BINARY_DIR}" PARENT_SCOPE)
+
+    # The way that CLion manages multiple configurations, it causes a copy of
+    # the CMakeCache.txt to be copied across due to it not expecting there to
+    # be a project within a project.  This causes the hard-coded paths in the
+    # cache to be copied and builds to fail.  To mitigate this, we simply
+    # remove the cache if it exists before we configure the new project.  It
+    # is safe to do so because it will be re-generated.  Since this is only
+    # executed at the configure step, it should not cause additional builds or
+    # downloads.
+    file(REMOVE "${DL_ARGS_DOWNLOAD_DIR}/CMakeCache.txt")
+
+    # Create and build a separate CMake project to carry out the download.
+    # If we've already previously done these steps, they will not cause
+    # anything to be updated, so extra rebuilds of the project won't occur.
+    # Make sure to pass through CMAKE_MAKE_PROGRAM in case the main project
+    # has this set to something not findable on the PATH.
+    configure_file("${_DownloadProjectDir}/DownloadProject.CMakeLists.txt.in"
+                   "${DL_ARGS_DOWNLOAD_DIR}/CMakeLists.txt" @ONLY)
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
+                        -D "CMAKE_MAKE_PROGRAM:FILE=${CMAKE_MAKE_PROGRAM}"
+                        .
+                    RESULT_VARIABLE result
+                    ${OUTPUT_QUIET}
+                    WORKING_DIRECTORY ${DL_ARGS_DOWNLOAD_DIR}
+    )
+    if(result)
+        message(FATAL_ERROR "CMake step for ${DL_ARGS_PROJ} failed: ${result}")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} --build ${DL_ARGS_DOWNLOAD_DIR}
+                    RESULT_VARIABLE result
+                    ${OUTPUT_QUIET}
+    )
+    if(result)
+        message(FATAL_ERROR "Build step for ${DL_ARGS_PROJ} failed: ${result}")
+    endif()
+
+endfunction()

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -23,13 +23,7 @@ git_get_changeset_id(C4REVISION)
 # Get year
 ############################################################################
 
-IF(CMAKE_HOST_UNIX)
-	EXECUTE_PROCESS(COMMAND "date" "+%Y" OUTPUT_VARIABLE DATE)
-ELSEIF(CMAKE_HOST_WIN32)
-	EXECUTE_PROCESS(COMMAND "cscript.exe" "//nologo" "${CMAKE_CURRENT_SOURCE_DIR}/tools/get_current_year.vbs" OUTPUT_VARIABLE DATE)
-ENDIF()
-STRING(REGEX REPLACE "(.+)\n" "\\1" YEARFIXED "${DATE}")
-SET(C4COPYRIGHT_YEAR ${YEARFIXED})
+STRING(TIMESTAMP C4COPYRIGHT_YEAR "%Y")
 
 ############################################################################
 # Build version strings

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,78 +16,28 @@ set(C4SCRIPT_SOURCES
 	../include/c4script/c4script.h
 	../src/C4Include.cpp
 	../src/script/C4ScriptStandalone.cpp
-    ../src/script/C4ScriptStandaloneStubs.cpp
+	../src/script/C4ScriptStandaloneStubs.cpp
 )
 
-# Look for GTest and GMock
-# GMock's source package ships GTest too, so look for it first
-find_path(GMOCK_ROOT
-    NAMES "gmock-all.cc" "src/gmock-all.cc" "gmock/gmock-all.cc"
-    PATHS "/usr/src/gmock"
-    )
-find_path(GMOCK_INCLUDE_DIR
-    NAMES "gmock/gmock.h"
-    HINTS "${GMOCK_ROOT}"
-    PATH_SUFFIXES "include"
-    )
-find_file(GMOCK_SOURCE_ALL
-    NAMES "gmock-all.cc"
-    HINTS "${GMOCK_ROOT}"
-    PATH_SUFFIXES "src" "gtest"
-    NO_DEFAULT_PATH
-    )
+include(DownloadProject)
+download_project(
+	PROJ     googletest
+	URL      https://github.com/google/googletest/archive/release-1.8.0.tar.gz
+	URL_HASH SHA256=58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8
+)
 
-find_path(GTEST_ROOT
-    NAMES "src/gtest-all.cc" "gtest/gtest-all.cc"
-    PATHS "${GMOCK_ROOT}" "/usr/src/gtest"
-    )
-find_path(GTEST_INCLUDE_DIR
-    NAMES "gtest/gtest.h"
-    HINTS "${GTEST_ROOT}"
-    PATH_SUFFIXES "include"
-    )
-find_file(GTEST_SOURCE_ALL
-    NAMES "gtest-all.cc"
-    HINTS "${GTEST_ROOT}"
-    PATH_SUFFIXES "src" "gtest"
-    NO_DEFAULT_PATH
-    )
+# Prevent GoogleTest from overriding our compiler/linker options
+# when building with Visual Studio
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-if (GMOCK_SOURCE_ALL AND GMOCK_INCLUDE_DIR)
-    add_library(gmock STATIC
-        "${GMOCK_SOURCE_ALL}"
-        "${GMOCK_INCLUDE_DIR}/gmock/gmock.h"
-        )
-	set_property(TARGET gmock PROPERTY FOLDER "Third-party libraries")
-    if (GMOCK_ROOT)
-        include_directories("${GMOCK_ROOT}")
-    endif()
-    include_directories("${GMOCK_INCLUDE_DIR}")
-    set(GMOCK_FOUND 1)
-endif()
-
-if (GTEST_SOURCE_ALL AND GTEST_INCLUDE_DIR)
-    add_library(gtest STATIC
-        "${GTEST_SOURCE_ALL}"
-        "${GTEST_INCLUDE_DIR}/gtest/gtest.h"
-        )
-	set_property(TARGET gtest PROPERTY FOLDER "Third-party libraries")
-    if (GTEST_ROOT)
-        include_directories("${GTEST_ROOT}")
-    endif()
-     if(HAVE_PTHREAD)
-        target_link_libraries(gtest pthread)
-    endif()
-    include_directories("${GTEST_INCLUDE_DIR}")
-    set(GTEST_FOUND 1)
-endif()
+add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
 
 include(CMakeParseArguments)
 function(create_test testName)
-    set(oneValueArgs "")
-    set(multiValueArgs SOURCES LIBRARIES)
-    CMAKE_PARSE_ARGUMENTS(CT "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-    add_executable("${testName}" EXCLUDE_FROM_ALL
+	set(oneValueArgs "")
+	set(multiValueArgs SOURCES LIBRARIES)
+	CMAKE_PARSE_ARGUMENTS(CT "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+	add_executable("${testName}"
 		${CT_SOURCES}
 		TestLog.cpp
 		TestLog.h
@@ -95,61 +45,53 @@ function(create_test testName)
 	)
 	target_include_directories("${testName}" PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
 	set_property(TARGET "${testName}" PROPERTY FOLDER "Testing")
-    target_link_libraries("${testName}" gtest gmock ${CT_LIBRARIES})
-    add_test(NAME "${testName}" COMMAND "${testName}")
+	target_link_libraries("${testName}" gtest gmock ${CT_LIBRARIES})
+	add_test(NAME "${testName}" COMMAND "${testName}")
+	set_tests_properties(${testName} PROPERTIES ENVIRONMENT "PATH=${CMAKE_ADDITIONAL_DEPS_PATH}/bin;$ENV{PATH}")
 endfunction()
 
-if (GTEST_FOUND AND GMOCK_FOUND)
-    enable_testing()
+create_test(StdMeshMath
+	SOURCES
+		../src/lib/StdMeshMath.cpp
+		../src/lib/StdMeshMath.h
+		math/StdMeshVectorTest.cpp
+		math/StdMeshQuaternionTest.cpp
+)
 
-    create_test(StdMeshMath
-        SOURCES
-        "../src/lib/StdMeshMath.cpp"
-        "../src/lib/StdMeshMath.h"
-        "math/StdMeshVectorTest.cpp"
-        "math/StdMeshQuaternionTest.cpp"
-        )
-
-    AUX_SOURCE_DIRECTORY("${CMAKE_CURRENT_LIST_DIR}" TESTS_SOURCES)
-    add_executable(tests EXCLUDE_FROM_ALL ${TESTS_SOURCES} ${C4SCRIPT_SOURCES})
-	set_property(TARGET "tests" PROPERTY FOLDER "Testing")
-    target_link_libraries(tests gtest libc4script libmisc)
-    if(UNIX AND NOT APPLE)
-	    target_link_libraries(tests rt)
-    endif()
-    if(WIN32)
-        target_link_libraries(tests winmm)
-    endif()
-
-    create_test(aul_test
-        SOURCES
-            aul/AulTest.cpp
-			aul/AulTest.h
-			aul/AulMathTest.cpp
-			aul/AulPredefinedFunctionTest.cpp
-			aul/AulDeathTest.cpp
-			aul/AulDiagnosticsTest.cpp
-			aul/AulSyntaxTest.cpp
-			aul/AulSyntaxTestDetail.h
-			aul/ErrorHandler.h
-            ../src/script/C4ScriptStandaloneStubs.cpp
-            ../src/script/C4ScriptStandalone.cpp
-        LIBRARIES
-            libmisc
-            libc4script)
-else()
-    set(_gtest_missing "")
-    if (NOT GTEST_INCLUDE_DIR)
-        set(_gtest_missing "${_gtest_missing} gtest/gtest.h")
-    endif()
-    if (NOT GTEST_SOURCE_ALL)
-        set(_gtest_missing "${_gtest_missing} gtest-all.cc")
-    endif()
-    if (NOT GMOCK_INCLUDE_DIR)
-        set(_gtest_missing "${_gtest_missing} gmock/gmock.h")
-    endif()
-    if (NOT GMOCK_SOURCE_ALL)
-        set(_gtest_missing "${_gtest_missing} gmock-all.cc")
-    endif()
-    message(STATUS "Could NOT find GTest/GMock (missing:${_gtest_missing})")
+if(UNIX AND NOT APPLE)
+	set(tests_LIBRARIES rt)
 endif()
+if(WIN32)
+	set(tests_LIBRARIES winmm)
+endif()
+
+create_test(tests
+	SOURCES
+		C4NetIOTest.cpp
+		C4StringTableTest.cpp
+		C4ValueTest.cpp
+		DirectExecTest.cpp
+		UnicodeHandlingTest.cpp
+		${C4SCRIPT_SOURCES}
+	LIBRARIES
+		libc4script
+		libmisc
+		${tests_LIBRARIES}
+)
+
+create_test(aul_test
+	SOURCES
+		aul/AulTest.cpp
+		aul/AulTest.h
+		aul/AulMathTest.cpp
+		aul/AulPredefinedFunctionTest.cpp
+		aul/AulDeathTest.cpp
+		aul/AulDiagnosticsTest.cpp
+		aul/AulSyntaxTest.cpp
+		aul/AulSyntaxTestDetail.h
+		aul/ErrorHandler.h
+		../src/script/C4ScriptStandaloneStubs.cpp
+		../src/script/C4ScriptStandalone.cpp
+	LIBRARIES
+		libmisc
+		libc4script)

--- a/tools/get_current_year.vbs
+++ b/tools/get_current_year.vbs
@@ -1,1 +1,0 @@
-Wscript.Echo DatePart("yyyy", Date()) 


### PR DESCRIPTION
Modify a few things CMake can do better:
- get the time-stamp (in this case the year).
- fetch `googletest` (or generally allowing any external CMake project) using [DownloadProject](https://github.com/Crascit/DownloadProject) from @Crascit, which generalizes [the technique mentioned in `googletest`'s README.md](https://github.com/google/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project). The differences from master:
  - rename DownloadProject.CMakeLists.cmake.in -> DownloadProject.CMakeLists.txt.in
  - use the `@VAR@` syntax for `configure_file` with `@ONLY` option.
  - specify the build directory in the `cmake --build` command rather than using the `WORKING_DIRECTORY` option from `execute_process`.
- upgrade `googletest` to version 1.8.0.
- add tests to the `all` target and use `ctest` for running them.
  - building tests can be disabled with the `-DBUILD_TESTING=NO` option.

A local Windows (MSVC) build and Travis Linux builds succeeded and the tests passed.