### PR TITLE
Share time information (frameCounter and realtime) with landscape shaders

### DIFF
--- a/src/graphics/C4Shader.h
+++ b/src/graphics/C4Shader.h
@@ -210,6 +210,34 @@ public:
 		if (pShader->HaveUniform(iUniform))
 			glUniform1i(pShader->GetUniform(iUniform), iX);
 	}
+	void SetUniform2i(int iUniform, int iX, int iY) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform2i(pShader->GetUniform(iUniform), iX, iY);
+	}
+	void SetUniform3i(int iUniform, int iX, int iY, int iZ) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform3i(pShader->GetUniform(iUniform), iX, iY, iZ);
+	}
+	void SetUniform4i(int iUniform, int iX, int iY, int iZ, int iW) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform4i(pShader->GetUniform(iUniform), iX, iY, iZ, iW);
+	}
+	void SetUniform1ui(int iUniform, unsigned int iX) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform1ui(pShader->GetUniform(iUniform), iX);
+	}
+	void Setuniform2ui(int iUniform, unsigned int iX, unsigned int iY) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform2ui(pShader->GetUniform(iUniform), iX, iY);
+	}
+	void Setuniform3ui(int iUniform, unsigned int iX, unsigned int iY, unsigned int iZ) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform3ui(pShader->GetUniform(iUniform), iX, iY, iZ);
+	}
+	void Setuniform4ui(int iUniform, unsigned int iX, unsigned int iY, unsigned int iZ, unsigned int iW) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform4ui(pShader->GetUniform(iUniform), iX, iY, iZ, iW);
+	}
 	void SetUniform1f(int iUniform, float gX) const {
 		if (pShader->HaveUniform(iUniform))
 			glUniform1f(pShader->GetUniform(iUniform), gX);
@@ -218,9 +246,45 @@ public:
 		if (pShader->HaveUniform(iUniform))
 			glUniform2f(pShader->GetUniform(iUniform), gX, gY);
 	}
+	void SetUniform3f(int iUniform, float gX, float gY, float gZ) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform3f(pShader->GetUniform(iUniform), gX, gY, gZ);
+	}
+	void SetUniform4f(int iUniform, float gX, float gY, float gZ, float gW) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform4f(pShader->GetUniform(iUniform), gX, gY, gZ, gW);
+	}
 	void SetUniform1iv(int iUniform, int iLength, const int *pVals) const {
 		if (pShader->HaveUniform(iUniform))
 			glUniform1iv(pShader->GetUniform(iUniform), iLength, pVals);
+	}
+	void SetUniform2iv(int iUniform, int iLength, const int *pVals) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform2iv(pShader->GetUniform(iUniform), iLength, pVals);
+	}
+	void SetUniform3iv(int iUniform, int iLength, const int *pVals) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform3iv(pShader->GetUniform(iUniform), iLength, pVals);
+	}
+	void SetUniform4iv(int iUniform, int iLength, const int *pVals) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform4iv(pShader->GetUniform(iUniform), iLength, pVals);
+	}
+	void SetUniform1uiv(int iUniform, int iLength, const unsigned int *pVals) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform1uiv(pShader->GetUniform(iUniform), iLength, pVals);
+	}
+	void SetUniform2uiv(int iUniform, int iLength, const unsigned int *pVals) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform2uiv(pShader->GetUniform(iUniform), iLength, pVals);
+	}
+	void SetUniform3uiv(int iUniform, int iLength, const unsigned int *pVals) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform3uiv(pShader->GetUniform(iUniform), iLength, pVals);
+	}
+	void SetUniform4uiv(int iUniform, int iLength, const unsigned int *pVals) const {
+		if (pShader->HaveUniform(iUniform))
+			glUniform4uiv(pShader->GetUniform(iUniform), iLength, pVals);
 	}
 	void SetUniform1fv(int iUniform, int iLength, const float *pVals) const {
 		if (pShader->HaveUniform(iUniform))

--- a/src/landscape/C4LandscapeRender.cpp
+++ b/src/landscape/C4LandscapeRender.cpp
@@ -71,6 +71,9 @@ bool C4LandscapeRenderGL::Init(int32_t iWidth, int32_t iHeight, C4TextureMap *pT
 	this->iHeight = iHeight;
 	this->pTexs = pTexs;
 
+	// Start timer
+	this->TimerStart = std::chrono::steady_clock::now();
+
 	// Allocate landscape textures
 	if (!InitLandscapeTexture())
 	{
@@ -631,6 +634,8 @@ bool C4LandscapeRenderGL::LoadShaders(C4GroupSet *pGroups)
 	UniformNames[C4LRU_AmbientBrightness] = "ambientBrightness";
 	UniformNames[C4LRU_AmbientTransform]  = "ambientTransform";
 	UniformNames[C4LRU_Modulation]        = "clrMod";
+	UniformNames[C4LRU_FrameCounter]      = "frameCounter";
+	UniformNames[C4LRU_Time]              = "time";
 
 	if(!LoadShader(pGroups, Shader, "landscape", 0))
 		return false;
@@ -976,6 +981,12 @@ void C4LandscapeRenderGL::Draw(const C4TargetFacet &cgo, const C4FoWRegion *Ligh
 		ShaderCall.SetUniformMatrix2x3fv(C4LRU_AmbientTransform, 1, ambientTransform);
 		ShaderCall.SetUniform1f(C4LRU_AmbientBrightness, Light->getFoW()->Ambient.GetBrightness());
 	}
+
+	// time information
+	ShaderCall.SetUniform1i(C4LRU_FrameCounter, ::Game.FrameCounter);
+	const auto now = std::chrono::steady_clock::now();
+	const int epoch = std::chrono::duration_cast<std::chrono::milliseconds>(now - TimerStart).count();
+	ShaderCall.SetUniform1i(C4LRU_Time, epoch);
 
 	pDraw->scriptUniform.Apply(ShaderCall);
 

--- a/src/landscape/C4LandscapeRender.h
+++ b/src/landscape/C4LandscapeRender.h
@@ -22,6 +22,8 @@
 #include "graphics/C4Shader.h"
 #include "graphics/C4Surface.h"
 
+#include <chrono>
+
 // Data we want to store per landscape pixel
 enum C4LR_Byte {
 	C4LR_Material,
@@ -54,6 +56,9 @@ enum C4LR_Uniforms
 	C4LRU_AmbientBrightness,
 	C4LRU_AmbientTransform,
 	C4LRU_Modulation,
+
+	C4LRU_FrameCounter,
+	C4LRU_Time,
 
 	C4LRU_Count
 };
@@ -136,6 +141,9 @@ private:
 
 	// scaler image
 	C4FacetSurface fctScaler;
+
+	// shader timer
+	std::chrono::time_point<std::chrono::steady_clock> TimerStart;
 
 public:
 	bool ReInit(int32_t iWidth, int32_t iHeight) override;


### PR DESCRIPTION
![ezgif-4-042f1b8f99](https://user-images.githubusercontent.com/4492427/28047663-dd0d3244-65eb-11e7-85ac-becec4efc055.gif)

It uses a int32[2]-vector for the realtime because ARB_gpu_shader_fp64 is not very well supported before OpenGL 4.0 on some Intel GPUs.