### PR TITLE
Replaced a comment with more accurate one

### DIFF
--- a/planet/Objects.ocd/Items.ocd/Tools.ocd/TeleGlove.ocd/Script.c
+++ b/planet/Objects.ocd/Items.ocd/Tools.ocd/TeleGlove.ocd/Script.c
@@ -271,7 +271,7 @@ protected func CancelUse(object clonk)
 /*-- Production --*/
 
 func IsInventorProduct() { return true; }
-public func GetSubstituteComponent(id component) // Can be made from diamong, ruby or amethyst
+public func GetSubstituteComponent(id component) // Can also be made from items returned by this method
 {
 	if (component == Diamond)
 		return [Ruby, Amethyst];


### PR DESCRIPTION
It was easy to forget about updating the old comment (https://github.com/openclonk/openclonk/commit/5c45d7a08e1f9a9dc691248cb781b6119853ff35) after changing the
code below it, which would make that comment confusing and irrelevant. It
wasn't accurate, because those weren't the only items that could be used
to make Tele Glove. It also had a typo in word diamond.