### PR TITLE
Fix Scoreboard libraries

### DIFF
--- a/planet/Arena.ocf/DarkMine.ocs/Script.c
+++ b/planet/Arena.ocf/DarkMine.ocs/Script.c
@@ -18,7 +18,6 @@ protected func Initialize()
 	if (SCENPAR_GameMode == GAMEMODE_Deathmatch)
 	{
 		CreateObject(Goal_DeathMatch);
-		GetRelaunchRule()->SetDefaultRelaunchCount(Max(SCENPAR_NrRelaunchesKills, 0));
 	}
 	else if (SCENPAR_GameMode == GAMEMODE_LastManStanding)
 	{

--- a/planet/Objects.ocd/Goals.ocd/DeathMatch.ocd/Script.c
+++ b/planet/Objects.ocd/Goals.ocd/DeathMatch.ocd/Script.c
@@ -27,15 +27,25 @@ func Initialize()
 	return _inherited(...);
 }
 
-protected func RelaunchPlayer(int plr, int killer)
+public func OnPlayerRelaunch(int plr, int killer, bool relaunch)
 {
-	_inherited(plr, killer, ...);
-	// Show scoreboard for a while
+	_inherited(plr, killer, relaunch, ...);
+	RelaunchScoreboardUpdate(plr);
+}
+
+private func RelaunchScoreboardUpdate(int plr)
+{
 	DoScoreboardShow(1, plr + 1);
 	Schedule(this,Format("DoScoreboardShow(-1, %d)", plr + 1), 35 * ShowBoardTime);
 	NotifyHUD();
-	return;
 }
+
+public func RelaunchPlayer(int plr, int killer)
+{
+	_inherited(plr, killer, ...);
+	RelaunchScoreboardUpdate(plr);
+}
+
 public func IsFulfilled()
 {
 	// Check whether someone has reached the limit.

--- a/planet/Objects.ocd/Libraries.ocd/Scoreboard.ocd/Death.ocd/Script.c
+++ b/planet/Objects.ocd/Libraries.ocd/Scoreboard.ocd/Death.ocd/Script.c
@@ -6,7 +6,7 @@
 		Make sure that the following functions return _inherited(...);
 			* Initialize();
 			* InitializePlayer(int plr);
-			* RelaunchPlayer(int plr, int killer);
+			* OnPlayerRelaunch(int plr, int killer, bool relaunch);
 			* RemovePlayer(int plr);
 --*/
 
@@ -45,13 +45,16 @@ protected func InitializePlayer(int plr)
 	return _inherited(plr, ...);
 }
 
-protected func RelaunchPlayer(int plr, int killer)
+protected func OnPlayerRelaunch(int plr, int killer, bool relaunch)
 {
-	var plrid = GetPlayerID(plr);
-	// Modify scoreboard death count entry for this player.
-	score_death_list[plrid]++;
-	Scoreboard->SetPlayerData(plr, "deaths", score_death_list[plrid]);
-	return _inherited(plr, killer, ...);
+	if (relaunch)
+	{
+		var plrid = GetPlayerID(plr);
+		// Modify scoreboard death count entry for this player.
+		score_death_list[plrid]++;
+		Scoreboard->SetPlayerData(plr, "deaths", score_death_list[plrid]);
+	}
+	return _inherited(plr, killer, relaunch, ...);
 }
 
 protected func RemovePlayer(int plr)

--- a/planet/Objects.ocd/Libraries.ocd/Scoreboard.ocd/Kill.ocd/Script.c
+++ b/planet/Objects.ocd/Libraries.ocd/Scoreboard.ocd/Kill.ocd/Script.c
@@ -35,17 +35,19 @@ protected func InitializePlayer(int plr)
 	return _inherited(plr, ...);
 }
 
-protected func RelaunchPlayer(int plr, int killer, bool relaunch)
+protected func OnPlayerRelaunch(int plr, int killer, bool relaunch)
 {
 	if (relaunch)
 	{
 		var plrid = GetPlayerID(killer);
+		
 		// Only if killer exists and has not committed suicide.
 		if (killer == plr || killer == NO_OWNER)
-			return _inherited(plr, killer, ...);
+			return _inherited(plr, killer, relaunch, ...);
+		
 		// Only if killer and victim are on different teams.
 		if (GetPlayerTeam(killer) && GetPlayerTeam(killer) == GetPlayerTeam(plr))
-			return _inherited(plr, killer, ...);
+			return _inherited(plr, killer, relaunch, ...);
 		// Modify scoreboard kill count entry for killer.
 		DoKillCount(plr, 1);
 	}

--- a/planet/Objects.ocd/Libraries.ocd/Scoreboard.ocd/Kill.ocd/Script.c
+++ b/planet/Objects.ocd/Libraries.ocd/Scoreboard.ocd/Kill.ocd/Script.c
@@ -6,7 +6,7 @@
 		Make sure that the following functions return _inherited(...);
 			* Initialize();
 			* InitializePlayer(int plr);
-			* RelaunchPlayer(int plr, int killer);
+			* OnPlayerRelaunch(int plr, int killer, bool relaunch);
 			* RemovePlayer(int plr);
 --*/
 
@@ -35,19 +35,21 @@ protected func InitializePlayer(int plr)
 	return _inherited(plr, ...);
 }
 
-protected func RelaunchPlayer(int plr, int killer)
+protected func RelaunchPlayer(int plr, int killer, bool relaunch)
 {
-	var plrid = GetPlayerID(killer);
-	// Only if killer exists and has not committed suicide.
-	if (killer == plr || killer == NO_OWNER)
-		return _inherited(plr, killer, ...);
-	// Only if killer and victim are on different teams.
-	if (GetPlayerTeam(killer) && GetPlayerTeam(killer) == GetPlayerTeam(plr))
-		return _inherited(plr, killer, ...);
-	// Modify scoreboard kill count entry for killer.
-	score_kill_list[plrid]++;
-	Scoreboard->SetPlayerData(killer, "kills", score_kill_list[plrid]);
-	return _inherited(plr, killer, ...);
+	if (relaunch)
+	{
+		var plrid = GetPlayerID(killer);
+		// Only if killer exists and has not committed suicide.
+		if (killer == plr || killer == NO_OWNER)
+			return _inherited(plr, killer, ...);
+		// Only if killer and victim are on different teams.
+		if (GetPlayerTeam(killer) && GetPlayerTeam(killer) == GetPlayerTeam(plr))
+			return _inherited(plr, killer, ...);
+		// Modify scoreboard kill count entry for killer.
+		DoKillCount(plr, 1);
+	}
+	return _inherited(plr, killer, relaunch, ...);
 }
 
 protected func RemovePlayer(int plr)

--- a/planet/Objects.ocd/Libraries.ocd/Scoreboard.ocd/KillStreak.ocd/Script.c
+++ b/planet/Objects.ocd/Libraries.ocd/Scoreboard.ocd/KillStreak.ocd/Script.c
@@ -35,22 +35,29 @@ protected func InitializePlayer(int plr)
 	return _inherited(plr, ...);
 }
 
-protected func RelaunchPlayer(int plr, int killer)
+protected func OnPlayerRelaunch(int plr, int killer, bool relaunch)
 {
-	var plrid = GetPlayerID(plr);
-	var killerid = GetPlayerID(killer);
-	// reset scoreboard kill streak count entry for killed player.
-	score_killstreak_list[plrid] = 0;
-	Scoreboard->SetPlayerData(plr, "killstreaks", nil);
-// Only if killer exists and has not committed suicide.
-	if (plr == killer || !GetPlayerName(killer))
-		return _inherited(plr, killer, ...);
-	// Only if killer and victim are on different teams.
-	if (GetPlayerTeam(killer) && GetPlayerTeam(killer) == GetPlayerTeam(plr))
-		return _inherited(plr, killer, ...);
-	// Modify scoreboard kill streak count entry for killer.
-	score_killstreak_list[killerid]++;
-	Scoreboard->SetPlayerData(killer, "killstreaks", score_killstreak_list[killerid]);
+	if (relaunch)
+	{
+		var plrid = GetPlayerID(plr);
+		var killerid = GetPlayerID(killer);
+		
+		// reset scoreboard kill streak count entry for killed player.
+		score_killstreak_list[plrid] = 0;
+		Scoreboard->SetPlayerData(plr, "killstreaks", nil);
+		
+		// Only if killer exists and has not committed suicide.
+		if (plr == killer || !GetPlayerName(killer))
+			return _inherited(plr, killer, relaunch, ...);
+		
+		// Only if killer and victim are on different teams.
+		if (GetPlayerTeam(killer) && GetPlayerTeam(killer) == GetPlayerTeam(plr))
+			return _inherited(plr, killer, relaunch, ...);
+		
+		// Modify scoreboard kill streak count entry for killer.
+		score_killstreak_list[killerid]++;
+		Scoreboard->SetPlayerData(killer, "killstreaks", score_killstreak_list[killerid]);
+	}
 	return _inherited(plr, killer, ...);
 }
 

--- a/planet/Objects.ocd/Libraries.ocd/Scoreboard.ocd/Relaunch.ocd/Script.c
+++ b/planet/Objects.ocd/Libraries.ocd/Scoreboard.ocd/Relaunch.ocd/Script.c
@@ -7,6 +7,7 @@
 			* Initialize();
 			* InitializePlayer(int plr);
 			* RelaunchPlayer(int plr, int killer);
+			* OnPlayerRelaunch(int plr, int killer, bool relaunch);
 			* RemovePlayer(int plr);
 --*/
 
@@ -38,11 +39,11 @@ protected func RelaunchPlayer(int plr, int killer)
 	return _inherited(plr, killer, ...);
 }
 
-protected func OnPlayerRelaunch(int plr)
+protected func OnPlayerRelaunch(int plr, int killer, bool relaunch)
 {
     if (GetRelaunchRule()->HasUnlimitedRelaunches()) return;
 	Scoreboard->SetPlayerData(plr, "relaunches", GetRelaunchRule()->GetPlayerRelaunchCount(plr));
-	return _inherited(plr, ...);
+	return _inherited(plr, killer, relaunch, ...);
 }
 
 

--- a/planet/Objects.ocd/Rules.ocd/Relaunch.ocd/Script.c
+++ b/planet/Objects.ocd/Rules.ocd/Relaunch.ocd/Script.c
@@ -220,7 +220,7 @@ public func InitializePlayer(int plr)
 	if (!initial_relaunch || !perform_restart)
 		return;	
 	// Scenario script callback.
-	if (GameCallEx("OnPlayerRelaunch", plr, false))
+	if (GameCallEx("OnPlayerRelaunch", plr, nil, false))
 		return;
 	return DoRelaunch(plr, nil, nil, true);
 }
@@ -241,7 +241,7 @@ public func OnClonkDeath(object clonk, int killer)
 			return;
 		}
 	}
-	if (GameCallEx("OnPlayerRelaunch", plr, true))
+	if (GameCallEx("OnPlayerRelaunch", plr, killer, true))
 		return;
 	return DoRelaunch(plr, clonk, nil);
 }


### PR DESCRIPTION
The scoreboard libraries are using `RelaunchPlayer`, which is called by the engine, but not by `Rule_Relaunch`.