### PR TITLE
Slashfix

### DIFF
--- a/src/c4group/C4Group.cpp
+++ b/src/c4group/C4Group.cpp
@@ -519,7 +519,7 @@ bool C4Group::Open(const char *szGroupName, bool fCreate)
 	char szGroupNameN[_MAX_FNAME];
 	SCopy(szGroupName,szGroupNameN,_MAX_FNAME);
 	// Convert to native path
-	SReplaceChar(szGroupNameN, '\\', DirectorySeparator);
+	SReplaceChar(szGroupNameN, AltDirectorySeparator, DirectorySeparator);
 
 	// Real reference
 	if (FileExists(szGroupNameN))


### PR DESCRIPTION
On Win32 the scenario fails to load when there are forward-slashes in the Defintions. This change should fix it.