### PR TITLE
Script: Test SetLength parameter 0 for nil (GH #79)

### DIFF
--- a/src/script/C4Script.cpp
+++ b/src/script/C4Script.cpp
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 1998-2000, Matthes Bender
  * Copyright (c) 2001-2009, RedWolf Design GmbH, http://www.clonk.de/
- * Copyright (c) 2009-2016, The OpenClonk Team and contributors
+ * Copyright (c) 2009-2019, The OpenClonk Team and contributors
  *
  * Distributed under the terms of the ISC license; see accompanying file
  * "COPYING" for details.
@@ -811,9 +811,21 @@ static bool FnDeepEqual(C4PropList * _this, const C4Value & v1, const C4Value & 
 
 static void FnSetLength(C4PropList * _this, C4ValueArray *pArray, int iNewSize)
 {
-	// safety
-	if (iNewSize<0 || iNewSize > C4ValueArray::MaxSize)
-		throw C4AulExecError(FormatString("SetLength: invalid array size (%d)", iNewSize).getData());
+	if (!pArray)
+	{
+		throw C4AulExecError(strprintf(R"(call to "%s" parameter %d: passed %s, but expected %s)",
+			"SetLength", 1, GetC4VName(C4V_Nil), GetC4VName(C4V_Array))
+			.c_str()
+		);
+	}
+
+	if (iNewSize < 0 || iNewSize > C4ValueArray::MaxSize)
+	{
+		throw C4AulExecError(strprintf(R"(call to "SetLength": parameter 2: invalid array size (expected value between 0 and %d, but got %d)",
+			C4ValueArray::MaxSize, iNewSize)
+			.c_str()
+		);
+	}
 
 	// set new size
 	pArray->SetSize(iNewSize);

--- a/src/script/C4ValueArray.h
+++ b/src/script/C4ValueArray.h
@@ -23,7 +23,7 @@
 class C4ValueArray: public C4RefCnt
 {
 public:
-	enum { MaxSize = 1000000 }; // ye shalt not create arrays larger than that!
+	static const int MaxSize = 1000000; // ye shalt not create arrays larger than that!
 
 	C4ValueArray();
 	C4ValueArray(int32_t inSize);

--- a/tests/aul/AulDeathTest.cpp
+++ b/tests/aul/AulDeathTest.cpp
@@ -1,7 +1,7 @@
 /*
 * OpenClonk, http://www.openclonk.org
 *
-* Copyright (c) 2016, The OpenClonk Team and contributors
+* Copyright (c) 2016-2019, The OpenClonk Team and contributors
 *
 * Distributed under the terms of the ISC license; see accompanying file
 * "COPYING" for details.
@@ -43,6 +43,19 @@ TEST_F(AulDeathTest, issue1891)
 		try
 		{
 			RunExpr("eval(\"Sin(\\\"\\\")\")");
+		}
+		catch (C4AulExecError &)
+		{}
+	);
+}
+
+TEST_F(AulDeathTest, SetLengthWithNil)
+{
+	// Github #79: NULL dereference when SetLength is called with nil parameter
+	EXPECT_NO_DEATH(
+		try
+		{
+			RunExpr("SetLength(nil, 0)");
 		}
 		catch (C4AulExecError &)
 		{}


### PR DESCRIPTION
SetLength didn't check whether its first parameter was valid, and
attempted to dereference a NULL pointer when passed nil.