### PR TITLE
nix expression: fix build

### DIFF
--- a/tools/default.nix
+++ b/tools/default.nix
@@ -50,7 +50,6 @@ pkgs.stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -p $out/bin
-    ln -s $out/games/openclonk $out/bin/
   '';
 
 


### PR DESCRIPTION
Now that openclonk gets installed to bin, we don't need to (and
can't!) create the symlink anymore.