### PR TITLE
Better warning pragma parsing

### DIFF
--- a/src/script/C4AulParse.cpp
+++ b/src/script/C4AulParse.cpp
@@ -791,11 +791,11 @@ void C4AulParse::Parse_WarningPragma()
 	auto start = cursor;
 	cursor = std::find_if(start, end, IsWhiteSpace);
 	bool enable_warning = false;
-	if (std::equal(start, cursor, C4Aul_Warning_enable))
+	if (cursor - start == sizeof(C4Aul_Warning_enable) - 1 && std::equal(start, cursor, C4Aul_Warning_enable))
 	{
 		enable_warning = true;
 	}
-	else if (std::equal(start, cursor, C4Aul_Warning_disable))
+	else if (cursor - start == sizeof(C4Aul_Warning_disable) - 1 && std::equal(start, cursor, C4Aul_Warning_disable))
 	{
 		enable_warning = false;
 	}

--- a/src/script/C4AulParse.cpp
+++ b/src/script/C4AulParse.cpp
@@ -778,12 +778,9 @@ void C4AulParse::UnexpectedToken(const char * Expected)
 void C4AulParse::Parse_WarningPragma()
 {
 	assert(SEqual2(TokenSPos, C4AUL_Warning));
-	assert(std::isspace(TokenSPos[sizeof(C4AUL_Warning) - 1]));
-
-
-	// Read parameters in to string buffer. The sizeof() includes the terminating \0, but
-	// that's okay because we need to skip (at least) one whitespace character anyway.
-	std::string line(TokenSPos + sizeof(C4AUL_Warning), SPos);
+	
+	// Read parameters in to string buffer.
+	std::string line(TokenSPos + sizeof(C4AUL_Warning) - 1, SPos);
 	auto end = line.end();
 	auto cursor = std::find_if_not(begin(line), end, IsWhiteSpace);
 

--- a/tests/aul/AulSyntaxTest.cpp
+++ b/tests/aul/AulSyntaxTest.cpp
@@ -88,6 +88,14 @@ TEST(AulSyntaxTest, ParseSyntaxErrors)
 	EXPECT_THROW(ParseStatement("func Main() {}"), C4AulParseError);
 }
 
+TEST(AulSyntaxTest, PragmaWarningWithInsufficientData)
+{
+	EXPECT_THROW(ParseScript("#warning"), C4AulParseError);
+	EXPECT_THROW(ParseScript("#warning\n"), C4AulParseError);
+	EXPECT_THROW(ParseScript("#warning "), C4AulParseError);
+	EXPECT_THROW(ParseScript("#warning \n"), C4AulParseError);
+}
+
 using namespace ::aul::ast;
 TEST(AulSyntaxTest, ParseLiterals)
 {

--- a/tests/aul/AulSyntaxTest.cpp
+++ b/tests/aul/AulSyntaxTest.cpp
@@ -94,6 +94,10 @@ TEST(AulSyntaxTest, PragmaWarningWithInsufficientData)
 	EXPECT_THROW(ParseScript("#warning\n"), C4AulParseError);
 	EXPECT_THROW(ParseScript("#warning "), C4AulParseError);
 	EXPECT_THROW(ParseScript("#warning \n"), C4AulParseError);
+	EXPECT_THROW(ParseScript("#warning e"), C4AulParseError);
+	EXPECT_THROW(ParseScript("#warning enabl"), C4AulParseError);
+	EXPECT_THROW(ParseScript("#warning d"), C4AulParseError);
+	EXPECT_THROW(ParseScript("#warning disabl"), C4AulParseError);
 }
 
 using namespace ::aul::ast;


### PR DESCRIPTION
We were misparsing `#warning` pragmas which didn't have all of the required information. We shouldn't do that.