### PR TITLE
Allow Material property for map script algorithms.

### DIFF
--- a/docs/sdk/script/MapScript.xml
+++ b/docs/sdk/script/MapScript.xml
@@ -51,6 +51,8 @@ Blit(layer, [0,0,layer.Wdt/2,layer.Hgt]);</code>
     <text>Algorithms are defined as prop list with the Algo property set to one of the MAPALGO_* constants and additional algorithm parameters set as properties. They can then be passed to one of the drawing functions (Draw or Blit), which will evaluate the algorithm at all positions and draw pixel values accordingly.</text>
     <text>For example, the following code would draw rectangles of earth in a checkerboard pattern:</text>
     <code>Draw("Earth", {Algo=MAPALGO_RndChecker, Wdt=5, Hgt=5});</code>
+    <text>You can also set the material within the algorithm via the Material property. In that case, Blit has to be used for drawing. It is thus possible to use multiple materials within one Blit call.</text>
+    <code>Blit({Material="Earth", Algo=MAPALGO_RndChecker, Wdt=5, Hgt=5});</code>
     <text>In addition to pattern-generating algorithms, there are also modifier algorithms that take other algorithms as parameters. For example, the Turbulence algorithm jumbles all pixels of the underlying algorithm around to create a noisy pattern:</text>
     <code>var checkerboard = {Algo=MAPALGO_RndChecker, Wdt=10, Hgt=10};
 var jumbled_checkerboard = {Algo=MAPALGO_Turbulence, Amplitude=10, Scale=10, Op=checkerboard};
@@ -62,6 +64,17 @@ var copy_layer = Duplicate();
 Blit({Algo=MAPALGO_Scale, OffX=Wdt/2, X=-100, Op=copy_layer});
 </code>
     <text>Note: If you are using the target layer in a drawing command, always draw from a copy. Otherwise, the result is undefined.</text>
+    <text>Algorithms like MAPALGO_Or can be used to combine multiple algorithms. If different materials are set at different pixels of the operands, they will be preserved. The material can also be set later within a such a combination, which overrides the materials of the operands (in case they have been set.)</text>
+    <code>// Draws two gold rectangles
+Blit({Material="Gold", Algo=MAPALGO_Or, Op=[
+	{Algo=MAPALGO_Rect, X=5, Y=0, Wdt=10, Hgt=10},
+	{Algo=MAPALGO_Rect, X=20, Y=0, Wdt=10, Hgt=10}
+]});</code>
+    <code>// Draws a gold and an earth rectangle
+Blit({Algo=MAPALGO_Or, Op=[
+	{Material="Gold", Algo=MAPALGO_Rect, X=5, Y=0, Wdt=10, Hgt=10},
+	{Material="Earth", Algo=MAPALGO_Rect, X=20, Y=0, Wdt=10, Hgt=10}
+]});</code>
     <h>MAPALGO_Layer</h><part>
     <text>Returns the pixel value at the x,y position of the given layer. Instead of passing a MAPALGO_Layer prop list, layers can also be passed directly as algorithms.</text>
       <text><table><rowh><col>Parameter</col><col>Default</col><col>Meaning</col></rowh>

--- a/src/landscape/C4MapScript.h
+++ b/src/landscape/C4MapScript.h
@@ -27,6 +27,8 @@
 #include "script/C4Aul.h"
 #include "script/C4ScriptHost.h"
 
+bool FnParTexCol(C4String *mattex, uint8_t& fg, uint8_t& bg);
+
 // mattex masks: Array of bools for each possible material-texture index
 class C4MapScriptMatTexMask
 {
@@ -262,6 +264,15 @@ class C4MapScriptAlgoFilter : public C4MapScriptAlgoModifier
 public:
 	C4MapScriptAlgoFilter(const C4PropList *props);
 
+	bool operator () (int32_t x, int32_t y, uint8_t& fg, uint8_t& bg) const override;
+};
+
+class C4MapScriptAlgoSetMaterial : public C4MapScriptAlgo {
+	C4MapScriptAlgo *inner;
+	uint8_t fg, bg;
+public:
+	C4MapScriptAlgoSetMaterial(C4MapScriptAlgo *inner, int fg, int bg);
+	~C4MapScriptAlgoSetMaterial() override;
 	bool operator () (int32_t x, int32_t y, uint8_t& fg, uint8_t& bg) const override;
 };
 

--- a/src/script/C4StringTable.cpp
+++ b/src/script/C4StringTable.cpp
@@ -117,6 +117,7 @@ C4StringTable::C4StringTable()
 	P[P_LineWidth] = "LineWidth";
 	P[P_OffX] = "OffX";
 	P[P_OffY] = "OffY";
+	P[P_Material] = "Material";
 	P[P_Proplist] = "Proplist";
 	P[P_proplist] = "proplist";
 	P[P_FacetBase] = "FacetBase";

--- a/src/script/C4StringTable.h
+++ b/src/script/C4StringTable.h
@@ -349,6 +349,7 @@ enum C4PropertyName
 	P_LineWidth,
 	P_OffX,
 	P_OffY,
+	P_Material,
 	P_proplist,
 	P_Proplist,
 	P_FacetBase,


### PR DESCRIPTION
Adds a new internal algorithm _C4MapScriptAlgoSetMaterial_ and uses it, when the _Material_ property is used for an algorithm.