### PR TITLE
Use CMake's LTO/LTCG/IPO support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: required # for Qt libraries. Additionally, the virtualization builds are m
 
 matrix:
   include:
+    # "Legacy" build: oldest supported gcc and cmake
     - os: linux
       compiler: gcc
       addons:
@@ -13,11 +14,13 @@ matrix:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-4.9', 'build-essential', 'cmake3', 'libfreetype6-dev', 'libgl1-mesa-dev', 'libglew-dev', 'libgtk-3-dev', 'libjpeg-dev', 'libpng-dev', 'libsdl2-dev', 'libupnp-dev', 'libxrandr-dev', 'x11proto-core-dev', 'zlib1g-dev', 'libalut0', 'libgtest-dev']
       env: 
+          - OLD_CMAKE=1
           - CCOMPILER=gcc-4.9 
           - CXXCOMPILER=g++-4.9 
           - TYPE=Debug # somehow, the linking fails for release builds. If someone could fix that, that would be great. 
           - BSYS="Unix Makefiles#make -k"
 
+    # "Current" gcc build, used for snapshots
     - os: linux
       compiler: gcc
       addons:
@@ -25,7 +28,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - sourceline: ppa:beineri/opt-qt596-trusty
-          packages: ['g++-5', 'build-essential', 'cmake3', 'libpng-dev', 'libjpeg-dev', 'libfreetype6-dev', 'libglew-dev', 'libreadline-dev', 'libsdl2-dev', 'qt59base', 'libalut-dev', 'libvorbis-dev', 'libopenal-dev', 'libdw-dev', 'libgtest-dev', 'ninja-build']
+          packages: ['g++-5', 'build-essential', 'libpng-dev', 'libjpeg-dev', 'libfreetype6-dev', 'libglew-dev', 'libreadline-dev', 'libsdl2-dev', 'qt59base', 'libalut-dev', 'libvorbis-dev', 'libopenal-dev', 'libdw-dev', 'libgtest-dev', 'ninja-build']
       env:
           - CCOMPILER=gcc-5
           - CXXCOMPILER=g++-5
@@ -35,12 +38,13 @@ matrix:
           - UPLOAD_SNAPSHOT=1
           - CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=/usr -DWITH_AUTOMATIC_UPDATE=ON -DWITH_APPDIR_INSTALLATION=ON"
 
+    # "Current" clang build
     - os: linux
       compiler: clang
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8']
-          packages: ['clang-3.8', 'build-essential', 'cmake3', 'libfreetype6-dev', 'libgl1-mesa-dev', 'libglew-dev', 'libgtk-3-dev', 'libjpeg-dev', 'libpng-dev', 'libsdl2-dev', 'libupnp-dev', 'libxrandr-dev', 'x11proto-core-dev', 'zlib1g-dev', 'libalut0', 'ninja-build', 'libc++-dev', 'libc++1', 'libgtest-dev']
+          packages: ['clang-3.8', 'build-essential', 'libfreetype6-dev', 'libgl1-mesa-dev', 'libglew-dev', 'libgtk-3-dev', 'libjpeg-dev', 'libpng-dev', 'libsdl2-dev', 'libupnp-dev', 'libxrandr-dev', 'x11proto-core-dev', 'zlib1g-dev', 'libalut0', 'ninja-build', 'libc++-dev', 'libc++1', 'libgtest-dev']
       env: 
           - CCOMPILER=clang-3.8 
           - CXXCOMPILER=clang++-3.8 
@@ -50,6 +54,13 @@ matrix:
 
 before_install:
     - for t in test mock; do wget https://github.com/google/google$t/archive/release-1.7.0.tar.gz -Og$t.tgz && tar xvf g$t.tgz; done 
+    # Install current cmake version.
+    - >
+      if [ -z "$OLD_CMAKE" ]; then
+        CMAKE_VERSION=3.14.1
+        wget "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh"
+        sudo sh "cmake-${CMAKE_VERSION}-Linux-x86_64.sh" --skip-license --prefix=/usr/local
+      fi
 
 install:
     - '[ -e /opt/qt59/bin/qt59-env.sh ] && source /opt/qt59/bin/qt59-env.sh || echo building without Qt'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,65 +89,22 @@ include(CheckCXXCompilerFlag)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Enable link-time code generation. We have to do this manually because while
-# there is a INTERPROCEDURAL_OPTIMIZATION cmake flag, it's only implemented
-# for icc so far; https://cmake.org/Bug/view.php?id=15939
-function(add_linker_flags)
-	include(CMakeParseArguments)
-	set(options optimized debug)
-	set(oneValueArgs FLAGS)
-	set(multiValueArgs MODULES)
+# Try to enable link-time optimization / link-time code generation /
+# interprocedural optimization for release builds.
+if(POLICY CMP0069)
+	cmake_policy(SET CMP0069 NEW)
 
-	cmake_parse_arguments(_alf "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-	# Adds some linker flags to all optimized build configurations
-	set(_configurations "")
-	if(_alf_optimized)
-		list(APPEND _configurations MINSIZEREL RELWITHDEBINFO RELEASE)
-	endif()
-	if(_alf_debug)
-		list(APPEND _configurations DEBUG)
-	endif()
-
-	foreach(_module ${_alf_MODULES})
-		string(TOUPPER "${_module}" _obj_type)
-		foreach(_config ${_configurations})
-			set(CMAKE_${_obj_type}_LINKER_FLAGS_${_config} "${CMAKE_${_obj_type}_LINKER_FLAGS_${_config}} ${_alf_FLAGS}" PARENT_SCOPE)
+	include(CheckIPOSupported)
+	check_ipo_supported(RESULT result OUTPUT output)
+	if(result)
+		foreach(_config MINSIZEREL RELWITHDEBINFO RELEASE)
+			set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_${_config} TRUE)
 		endforeach()
-	endforeach()
-endfunction()
-
-CHECK_CXX_COMPILER_FLAG("-flto" USE_GCC_STYLE_LTCG)
-if(USE_GCC_STYLE_LTCG)
-	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -flto")
-	set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} -flto")
-	add_linker_flags(optimized MODULES exe shared FLAGS -flto)
-
-	# Use GCC's ar and ranlib wrappers if necessary, because the plain ones 
-	# don't understand lto objects without an explicit plugin parameter
-	# Note that versioned gcc executables need splitting: gcc-5 -> gcc-ar-5
-	if(CMAKE_C_COMPILER MATCHES "^(.*gcc)(-[0-9.])?$")
-		set(LTCG_NEEDS_AR_WRAPPER 1)
-		set(LTCG_AR_WRAPPER_PREFIX "${CMAKE_MATCH_1}")
-		set(LTCG_AR_WRAPPER_SUFFIX "${CMAKE_MATCH_2}")
-	elseif(CMAKE_C_COMPILER MATCHES "cc$")
-		set(LTCG_NEEDS_AR_WRAPPER 1)
-		set(LTCG_AR_WRAPPER_PREFIX "gcc")
 	else()
-		set(LTCG_NEEDS_AR_WRAPPER 0)
+		message(WARNING "IPO is not supported: ${output}")
 	endif()
-
-	if(LTCG_NEEDS_AR_WRAPPER)
-		find_program(AR_WRAPPER "${LTCG_AR_WRAPPER_PREFIX}-ar${LTCG_AR_WRAPPER_SUFFIX}")
-		if (AR_WRAPPER)
-			message("Using ${AR_WRAPPER} instead of ${CMAKE_AR} to support lto objects.")
-			set(CMAKE_AR "${AR_WRAPPER}" CACHE FILEPATH "Path to an ar that supports lto objects." FORCE)
-		endif()
-		find_program(RANLIB_WRAPPER "${LTCG_AR_WRAPPER_PREFIX}-ranlib${LTCG_AR_WRAPPER_SUFFIX}")
-		if (RANLIB_WRAPPER)
-			message("Using ${RANLIB_WRAPPER} instead of ${CMAKE_RANLIB} to support lto objects.")
-			set(CMAKE_RANLIB "${RANLIB_WRAPPER}" CACHE FILEPATH "Path to a ranlib that supports lto objects." FORCE)
-		endif()
-	endif()
+else()
+	message(WARNING "IPO is not supported because CMake is too old")
 endif()
 
 if(MSVC)
@@ -164,12 +121,6 @@ if(MSVC)
 
 	# Enable multi-core builds
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
-
-	# Enable LTCG for release builds
-	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /Ob2 /GL")
-	set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} /Ob2 /GL")
-	add_linker_flags(optimized MODULES exe shared FLAGS "/INCREMENTAL:NO")
-	add_linker_flags(optimized MODULES exe shared static FLAGS "/LTCG:incremental")
 
 	# do not link the release CRT in debug builds
 	set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /NODEFAULTLIB:MSVCRT")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,10 @@ if(MSVC)
 	# Enable multi-core builds
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 
+	# Fix inlining option that CMake overrides per default.
+	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /Ob2")    
+	set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} /Ob2")
+
 	# do not link the release CRT in debug builds
 	set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /NODEFAULTLIB:MSVCRT")
 	set(HAVE_PRECOMPILED_HEADERS ON CACHE INTERNAL "Compiler supports precompiled headers")


### PR DESCRIPTION
This requires at least CMake 3.9 for GCC and clang and 3.13 for MSVC.
Older versions will still work, but without LTO.

In contrast to the old variant, this now works with clang as well.

@isilkor: Can you check whether this does the right thing with MSVC?