### PR TITLE
Ambient light color

### DIFF
--- a/planet/Graphics.ocg/CommonShader.glsl
+++ b/planet/Graphics.ocg/CommonShader.glsl
@@ -11,6 +11,8 @@
 // uncomment the following lines to set the light color to pink for all lights for debugging:
 //#define LIGHT_DEBUG_PINK
 
+
+uniform vec3 ambientColor;
 #ifdef OC_DYNAMIC_LIGHT
 uniform sampler2D ambientTex;
 
@@ -133,6 +135,15 @@ slice(light)
 	light2 = mix(light2, ambientMul * (ambientAmbience + lightDot(normal2, ambientDir)), ambient);
 #endif
 	lightColor = mix(lightColor, vec3(1.0,1.0,1.0), ambient);
+}
+
+slice(color+1)
+{
+	// That is not how light mixing works, but whatever, it looks nice ingame...
+	// Anyway: Without ambient light color the screen will be fairly dark (0.3),
+	// and colored light illuminates that to normal brightness, combined
+	// with the color that is already established.
+	fragColor = vec4(fragColor.rgb * (vec3(0.3, 0.3, 0.3) + 0.7 * ambientColor), fragColor.a);
 }
 
 slice(color+5)

--- a/src/game/C4GameScript.cpp
+++ b/src/game/C4GameScript.cpp
@@ -1242,6 +1242,23 @@ static long FnGetAmbientBrightness(C4PropList * _this)
 	return static_cast<long>(::Landscape.GetFoW()->Ambient.GetBrightness() * 100. + 0.5);
 }
 
+static void FnSetAmbientColor(C4PropList * _this, long iValue)
+{
+	if (::Landscape.HasFoW())
+	{
+		::Landscape.GetFoW()->Ambient.SetColor(iValue);
+	}
+}
+
+static long FnGetAmbientColor(C4PropList * _this)
+{
+	if (::Landscape.HasFoW())
+	{
+		return ::Landscape.GetFoW()->Ambient.GetColor();
+	}
+	return 0xffffffff;
+}
+
 static void FnSetSeason(C4PropList * _this, long iSeason)
 {
 	::Weather.SetSeason(iSeason);
@@ -2851,6 +2868,8 @@ void InitGameFunctionMap(C4AulScriptEngine *pEngine)
 	F(LandscapeHeight);
 	F(SetAmbientBrightness);
 	F(GetAmbientBrightness);
+	F(SetAmbientColor);
+	F(GetAmbientColor);
 	F(SetSeason);
 	F(GetSeason);
 	F(SetClimate);

--- a/src/graphics/C4DrawGL.cpp
+++ b/src/graphics/C4DrawGL.cpp
@@ -213,6 +213,7 @@ bool CStdGL::PrepareSpriteShader(C4Shader& shader, const char* name, int ssc, C4
 	uniformNames[C4SSU_AmbientTex] = "ambientTex";
 	uniformNames[C4SSU_AmbientTransform] = "ambientTransform";
 	uniformNames[C4SSU_AmbientBrightness] = "ambientBrightness";
+	uniformNames[C4SSU_AmbientColor] = "ambientColor";
 	uniformNames[C4SSU_MaterialAmbient] = "materialAmbient"; // unused
 	uniformNames[C4SSU_MaterialDiffuse] = "materialDiffuse"; // unused
 	uniformNames[C4SSU_MaterialSpecular] = "materialSpecular"; // unused
@@ -432,6 +433,7 @@ void CStdGL::SetupMultiBlt(C4ShaderCall& call, const C4BltTransform* pTransform,
 		call.AllocTexUnit(C4SSU_AmbientTex);
 		glBindTexture(GL_TEXTURE_2D, pFoW->getFoW()->Ambient.Tex);
 		call.SetUniform1f(C4SSU_AmbientBrightness, pFoW->getFoW()->Ambient.GetBrightness());
+		call.SetUniform3fv(C4SSU_AmbientColor, 1, pFoW->getFoW()->Ambient.GetColorRGB());
 
 		float ambientTransform[6];
 		pFoW->getFoW()->Ambient.GetFragTransform(vpRect, ClipRect, OutRect, ambientTransform);

--- a/src/graphics/C4DrawGL.h
+++ b/src/graphics/C4DrawGL.h
@@ -68,6 +68,7 @@ enum C4SS_Uniforms
 	C4SSU_AmbientTex, // C4SSC_LIGHT
 	C4SSU_AmbientTransform, // C4SSC_LIGHT
 	C4SSU_AmbientBrightness, // C4SSC_LIGHT
+	C4SSU_AmbientColor, // C4SSC_LIGHT
 
 	C4SSU_MaterialAmbient, // for meshes
 	C4SSU_MaterialDiffuse, // for meshes

--- a/src/graphics/C4DrawMeshGL.cpp
+++ b/src/graphics/C4DrawMeshGL.cpp
@@ -538,6 +538,7 @@ namespace
 			call.AllocTexUnit(C4SSU_AmbientTex);
 			glBindTexture(GL_TEXTURE_2D, pFoW->getFoW()->Ambient.Tex);
 			call.SetUniform1f(C4SSU_AmbientBrightness, pFoW->getFoW()->Ambient.GetBrightness());
+			call.SetUniform3fv(C4SSU_AmbientColor, 1, pFoW->getFoW()->Ambient.GetColorRGB());
 			float ambientTransform[6];
 			pFoW->getFoW()->Ambient.GetFragTransform(pFoW->getViewportRegion(), clipRect, outRect, ambientTransform);
 			call.SetUniformMatrix2x3fv(C4SSU_AmbientTransform, 1, ambientTransform);

--- a/src/landscape/fow/C4FoWAmbient.cpp
+++ b/src/landscape/fow/C4FoWAmbient.cpp
@@ -17,6 +17,7 @@
 #include "C4ForbidLibraryCompilation.h"
 #include "landscape/fow/C4FoWAmbient.h"
 #include "landscape/fow/C4FoW.h"
+#include "lib/StdColors.h"
 #include "graphics/C4Draw.h"
 
 namespace
@@ -215,4 +216,21 @@ void C4FoWAmbient::GetFragTransform(const FLOAT_RECT& vpRect, const C4Rect& clip
 
 	// Extract matrix
 	trans.Get2x3(ambientTransform);
+}
+
+void C4FoWAmbient::SetColor(long color)
+{
+	Color = color;
+	colorR = GetRedValue(color) / 255.0f;
+	colorG = GetGreenValue(color) / 255.0f;
+	colorB = GetBlueValue(color) / 255.0f;
+
+	float min = std::min(colorR, std::min(colorG, colorB));
+	colorV = std::max(std::max(colorR, std::max(colorG, colorB)), 1e-3f); // Prevent division by 0
+	colorL = (min + colorV) / 2.0f;
+
+	// Maximize color, so that dark colors will not be desaturated after normalization
+	colorR = std::min(colorR / colorV, 1.0f);
+	colorG = std::min(colorG / colorV, 1.0f);
+	colorB = std::min(colorB / colorV, 1.0f);
 }

--- a/src/landscape/fow/C4FoWAmbient.h
+++ b/src/landscape/fow/C4FoWAmbient.h
@@ -49,11 +49,20 @@ private:
 	unsigned int SizeY{0};
 	// Brightness (not premultiplied)
 	double Brightness{1.};
+	long Color = 0xffffffff; // Return value for GetColor and object script
+	float colorR = 1.0; // red color component of the light source. 1.0 is maximum.
+	float colorG = 1.0; // green color component of the light source. 1.0 is maximum.
+	float colorB = 1.0; // blue color component of the light source. 1.0 is maximum.
+	float colorV = 1.0; // color value. 1.0 is maximum.
+	float colorL = 1.0; // color lightness. 1.0 is maximum.
 public:
 	void Clear();
 
 	void SetBrightness(double brightness) { Brightness = brightness; }
 	double GetBrightness() const { return Brightness; }
+	void SetColor(long color);
+	long GetColor() const { return Color; }
+	float *GetColorRGB() const { return new float[3] {colorR, colorG, colorB}; }
 
 	// High resolution will make the map coarser, but speed up the generation process
 	// and save video memory.

--- a/src/lib/StdMeshMaterial.cpp
+++ b/src/lib/StdMeshMaterial.cpp
@@ -862,6 +862,7 @@ bool StdMeshMaterialProgram::CompileShader(StdMeshMaterialLoader& loader, C4Shad
 	uniformNames[C4SSU_AmbientTex] = "ambientTex";
 	uniformNames[C4SSU_AmbientTransform] = "ambientTransform";
 	uniformNames[C4SSU_AmbientBrightness] = "ambientBrightness";
+	uniformNames[C4SSU_AmbientColor] = "ambientColor";
 	uniformNames[C4SSU_MaterialAmbient] = "materialAmbient";
 	uniformNames[C4SSU_MaterialDiffuse] = "materialDiffuse";
 	uniformNames[C4SSU_MaterialSpecular] = "materialSpecular";


### PR DESCRIPTION
For unknown reasons the ambient color uniform is available for the sky and objects only, but not for the landscape. 
Maybe I am missing something here, also the value does not have to be stored in the same class as the ambient brightness value.

Just noticed, that documentation is still missing.