### PR TITLE
Fix bug with incorrect OpenGL context after viewport closing in editor.

### DIFF
--- a/src/game/C4Viewport.cpp
+++ b/src/game/C4Viewport.cpp
@@ -900,6 +900,8 @@ bool C4ViewportList::CloseViewport(C4Viewport * cvp)
 				StartSoundEffect("UI::CloseViewport");
 			}
 		}
+	// Deleting a viewport may leave us with no context selected
+	if (pDraw) pDraw->EnsureMainContextSelected();
 	// Recalculate viewports
 	RecalculateViewports();
 	// Done

--- a/src/landscape/fow/C4FoW.cpp
+++ b/src/landscape/fow/C4FoW.cpp
@@ -27,7 +27,6 @@ C4FoW::~C4FoW()
 {
 	if (deleted_lights)
 	{
-		if (pDraw) pDraw->EnsureMainContextSelected();
 		ClearDeletedLights();
 	}
 }


### PR DESCRIPTION
See https://bugs.openclonk.org/view.php?id=2065

We need to have a context selected even if we don't draw, because buffer objects and textures may be created, which are just ignored otherwise.

The `EnsureMainContextSelected()` in `C4FoW::~C4FoW` was a bugfix for another bug, but I don't know how it can be reproduced. It's probably also fixed by this commit.
Setting the main context at that point is wrong anyway, because we may have another context already.