### PR TITLE
Fix crash on closing scenario in editor.

### DIFF
--- a/src/graphics/C4DrawGL.cpp
+++ b/src/graphics/C4DrawGL.cpp
@@ -727,6 +727,9 @@ C4Shader* CStdGL::GetSpriteShader(int ssc)
 
 bool CStdGL::InitShaders(C4GroupSet* pGroups)
 {
+	if (!pCurrCtx)
+		EnsureMainContextSelected();
+
 	// Create sprite blitting shaders
 	if(!PrepareSpriteShader(SpriteShader, "sprite", 0, pGroups, nullptr, nullptr))
 		return false;


### PR DESCRIPTION
See https://bugs.openclonk.org/view.php?id=2004

Caused by trying to create shaders with no active context.