### PR TITLE
Fix ranged weapon aiming

### DIFF
--- a/planet/Objects.ocd/Libraries.ocd/AimManager.ocd/Script.c
+++ b/planet/Objects.ocd/Libraries.ocd/AimManager.ocd/Script.c
@@ -460,10 +460,10 @@ public func ResetHands()
 func FxIntWalkSlowStart(pTarget, effect, fTmp, iValue)
 {
 	iValue = iValue ?? 420;
-	pTarget->PushActionSpeed("Walk", iValue);
+	pTarget->PushActionSpeed("Walk", iValue, Library_AimManager);
 }
 
 func FxIntWalkSlowStop(pTarget, effect)
 {
-	pTarget->PopActionSpeed("Walk", GetID());
+	pTarget->PopActionSpeed("Walk", Library_AimManager);
 }


### PR DESCRIPTION
Actually this branch was intended for luchs suggestion of making the bow auto-add an arrow first, and only start drawing when you press the button. This is not as easy to do and requires some changes in the aim manager (because adding an arrow is part of the drawing animation, and you'd have to split that and track some states in the bow). Doing that would be a separate PR, so I'll just merge the fix first.