### PR TITLE
Fix accident in C4Group

### DIFF
--- a/src/c4group/C4Group.cpp
+++ b/src/c4group/C4Group.cpp
@@ -1413,9 +1413,9 @@ bool C4Group::DeleteEntry(const char *szFilename, bool fRecycle)
 		{
 			if (!EraseItem(szPath)) return false;
 		}
-		break;
 		// refresh file list
 		ResetSearch(true);
+		break;
 	default: break; // InGrp & Deleted ignored
 	}
 	return true;


### PR DESCRIPTION
In commit 99992b6f47 it seems that the changes were added after the break by accident, resulting in dead code. However, this code did not seem to cause any problems, so I am not sure whether we need this chance