### PR TITLE
Fix a warning related to -headerpad_max_install_names in the macOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,8 @@ if(WIN32 AND MINGW)
 endif()
 
 if(APPLE)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fobjc-arc -headerpad_max_install_names")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fobjc-arc")
+	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -headerpad_max_install_names")
 endif()
 
 ############################################################################


### PR DESCRIPTION
This is a linker flag, not a compiler flag, so move it to
CMAKE_SHARED_LINKER_FLAGS.