### PR TITLE
Fix FindAudio's detection of Alut on macOS

### DIFF
--- a/cmake/FindAudio.cmake
+++ b/cmake/FindAudio.cmake
@@ -105,7 +105,7 @@ endif()
 # make sure the provider is available.
 if(Audio_TK STREQUAL "OpenAL")
 	__FINDAUDIO_FINDOPENAL()
-	if(OpenAL_FOUND AND (APPLE OR Alut_FOUND) AND OggVorbis_FOUND)
+	if(OpenAL_FOUND AND Alut_FOUND AND OggVorbis_FOUND)
 		set(Audio_FOUND TRUE)
 		set(Audio_LIBRARIES ${OpenAL_LIBRARIES} ${OggVorbis_LIBRARIES})
 		set(Audio_INCLUDE_DIRS ${OpenAL_INCLUDE_DIRS} ${OggVorbis_INCLUDE_DIRS})


### PR DESCRIPTION
Changeset cf474e9 removed one (APPLE OR) clause from FindAudio, but
missed the other one.  They need to match so that the detection logic
is correct.

Alut is required if AUDIO_TK == AUDIO_TK_OPENAL, because it's included
in C4SoundIncludes.h with no platform-specific conditionals.