### PR TITLE
Fix missing refs to GTK3_LIBRARY_DIRS / GTK3_gtksourceview_LIBRARY_DIRS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1266,6 +1266,10 @@ if(GTK3_FOUND AND GTK3_gtksourceview_FOUND AND NOT HEADLESS_ONLY AND NOT C4GROUP
 	target_compile_options(mape PRIVATE ${GTK3_COMPILE_DEFINITIONS} ${GTK3_gtksourceview_COMPILE_DEFINITIONS})
 	set_property(TARGET mape PROPERTY FOLDER "Utilities")
 	target_include_directories(mape PRIVATE ${GTK3_INCLUDE_DIRS} ${GTK3_gtksourceview_INCLUDE_DIRS})
+	target_link_directories(mape PRIVATE
+		${GTK3_LIBRARY_DIRS}
+		${GTK3_gtksourceview_LIBRARY_DIRS}
+	)
 	target_link_libraries(mape
 		${GTK3_LIBRARIES}
 		${GTK3_gtksourceview_LIBRARIES}


### PR DESCRIPTION
These need to be specified along with GTK3_LIBRARIES /
GTK3_gtksourceview_LIBRARIES, otherwise the libraries will not be found
(if they're on non-system paths).