### PR TITLE
Set the SKIP_AUTOGEN property on mape-resource.c.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -876,6 +876,7 @@ set(MAPE_SOURCES
 	src/mape/window.h
 	mape-resource.c
 )
+set_property(SOURCE mape-resource.c PROPERTY SKIP_AUTOGEN ON)
 
 # source files specific to an operating system
 if(APPLE)


### PR DESCRIPTION
This silences a warning from CMake "Policy CMP0071 is not set".