### PR TITLE
Fix macOS OpenGL initialization.

### DIFF
--- a/src/graphics/C4DrawGLMac.mm
+++ b/src/graphics/C4DrawGLMac.mm
@@ -602,6 +602,7 @@ bool CStdGLCtx::Init(C4Window * pWindow, C4AbstractApp *)
 	if (controller && controller.openGLView)
 	{
 		[controller.openGLView setContext:ctx];
+		[ctx setView:controller.openGLView];
 	}
 
 	this_context = contexts.insert(contexts.end(), this);


### PR DESCRIPTION
Call [NSOpenGLContext setView:] when initializing the CStdGLCtx in
C4DrawGLMac.  This is sufficient to get graphics working in the macOS
build.