### PR TITLE
Do not strip executables in debug mode when using macdeployqt.

### DIFF
--- a/cmake/DeployQt.cmake
+++ b/cmake/DeployQt.cmake
@@ -82,6 +82,7 @@ function(macdeployqt target)
         COMMAND "${MACDEPLOYQT_EXECUTABLE}"
             \"$<TARGET_FILE_DIR:${target}>/../..\"
             -always-overwrite
+            $<$<CONFIG:Debug>:-no-strip>
         COMMENT "Deploying Qt..."
     )
 endfunction()


### PR DESCRIPTION
Pass macdeployqt the -no-strip flag when we're using the Debug CMake
configuration and DEPLOY_QT_LIBRARIES=1.  Otherwise, the main app gets
stripped, which defeats the point of a debug build.