### PR TITLE
Fix build of netpuncher and tests on macOS, and add a Travis macOS build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,12 @@ mape_autogen/
 netpuncher_autogen/
 openclonk-server_autogen/
 openclonk_autogen/
+tests/aul_test
+tests/aul_test_autogen/
+tests/gmock_autogen/
+tests/gtest_autogen/
+tests/tests
+tests/tests_autogen/
 thirdparty/blake2/blake2_autogen/
 
 # Temporary files created by Microsoft Visual Studio

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,20 @@ matrix:
           - TYPE=Debug 
           - BSYS="Ninja#ninja -k30"
 
+    # macOS build
+    - os: osx
+      compiler: clang
+      osx_image: xcode11.3
+      install:
+          - brew upgrade pkg-config  # https://github.com/Homebrew/brew/issues/5068, presumably can be removed soon
+          - brew install freealut glew libogg libvorbis sdl2
+      env:
+          - CXX_FLAGS="-fcolor-diagnostics"
+          - TYPE=RelWithDebInfo
+          - BSYS="Unix Makefiles#make -k"
+          - CMAKE_FLAGS="-DDEPLOY_QT_LIBRARIES=1 -DCMAKE_PREFIX_PATH=/usr/local/opt/openal-soft;/usr/local/opt/qt"
+          - OLD_CMAKE=1
+
 before_install:
     - for t in test mock; do wget https://github.com/google/google$t/archive/release-1.7.0.tar.gz -Og$t.tgz && tar xvf g$t.tgz; done 
     # Install current cmake version.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -885,7 +885,6 @@ if(APPLE)
 		src/platform/C4FileMonitorMac.mm
 		src/platform/C4AppDelegate.h
 		src/platform/C4AppDelegate.mm
-		src/platform/StdSchedulerMac.mm
 		src/platform/ObjectiveCAssociated.h
 	)
 	list(APPEND OC_GUI_SOURCES ${OC_BUNDLE_RESOURCES})
@@ -1030,6 +1029,7 @@ src/platform/StdFile.h
 src/platform/StdRegistry.cpp
 src/platform/StdRegistry.h
 src/platform/StdScheduler.cpp
+$<$<BOOL:${APPLE}>:src/platform/StdSchedulerMac.mm>
 src/platform/StdSchedulerWin32.cpp
 src/platform/StdSchedulerPoll.cpp
 src/platform/StdScheduler.h

--- a/tests/aul/AulDeathTest.cpp
+++ b/tests/aul/AulDeathTest.cpp
@@ -26,8 +26,14 @@ class AulDeathTest : public AulTest
 
 // DEATH_SUCCESS_CODE is arbitrarily chosen such that it's unlikely to be
 // returned by failing code.
+// macOS/clang/libc++ doesn't support quick_exit.
 #define DEATH_SUCCESS_CODE 86
-#define EXPECT_NO_DEATH(code) EXPECT_EXIT({code; std::quick_exit(DEATH_SUCCESS_CODE);}, ::testing::ExitedWithCode(DEATH_SUCCESS_CODE), "")
+#if defined(_LIBCPP_CSTDLIB) && !defined(_LIBCPP_HAS_QUICK_EXIT)
+#define QUICK_EXIT exit
+#else
+#define QUICK_EXIT quick_exit
+#endif
+#define EXPECT_NO_DEATH(code) EXPECT_EXIT({code; QUICK_EXIT(DEATH_SUCCESS_CODE);}, ::testing::ExitedWithCode(DEATH_SUCCESS_CODE), "")
 
 TEST_F(AulDeathTest, NestedFunctions)
 {


### PR DESCRIPTION
StdSchedulerMac needs to be included in libmisc so that the netpuncher
and tests targets can pick it up.  This is conditional on APPLE being set
(unlike the other StdScheduler* files) because the Travis builds for other
OSes do not have the Objective C++ compiler installed.  Also, there is an
earlier cset that implies that this was a problem more generally (515aaf6).

Clang/libc++ on macOS apparently doesn't support quick_exit, even with
-std=c++11.  Use a macro check in AulDeathTest to switch it to regular
exit instead.

Add test build output and autogen directories to .gitignore.