### PR TITLE
Fix slowness in deleting proplist references

### DIFF
--- a/src/script/C4PropList.cpp
+++ b/src/script/C4PropList.cpp
@@ -24,41 +24,17 @@
 
 void C4PropList::AddRef(C4Value *pRef)
 {
-#ifdef _DEBUG
-	C4Value * pVal = FirstRef;
-	while (pVal)
-	{
-		assert(pVal != pRef);
-		pVal = pVal->NextRef;
-	}
-#endif
-	pRef->NextRef = FirstRef;
-	FirstRef = pRef;
+	assert(Refs.count(pRef) == 0);
+	Refs.insert(pRef);
 }
 
-void C4PropList::DelRef(const C4Value * pRef, C4Value * pNextRef)
+void C4PropList::DelRef(C4Value * pRef)
 {
-	assert(FirstRef);
-	// References to objects never have HasBaseArray set
-	if (pRef == FirstRef)
-	{
-		FirstRef = pNextRef;
-		if (pNextRef) return;
-	}
-	else
-	{
-		C4Value *pPrev = FirstRef;
-		while (pPrev->NextRef != pRef)
-		{
-			pPrev = pPrev->NextRef;
-			assert(pPrev);
-		}
-		pPrev->NextRef = pNextRef;
-		return;
-	}
+	auto erased = Refs.erase(pRef);
+	assert(erased == 1);
 	// Only pure script proplists are garbage collected here, host proplists
 	// like definitions and effects have their own memory management.
-	if (Delete()) delete this;
+	if (Refs.empty() && Delete()) delete this;
 }
 
 C4PropList * C4PropList::New(C4PropList * prototype)
@@ -311,18 +287,13 @@ C4PropListStatic *C4PropList::FreezeAndMakeStaticRecursively(std::vector<C4Value
 		this_static = NewStatic(GetPrototype(), parent, key);
 		this_static->Properties.Swap(&Properties); // grab properties
 		this_static->Status = Status;
-		C4Value holder = C4VPropList(this);
-		while (FirstRef && FirstRef->NextRef)
-		{
-			C4Value *ref = FirstRef;
-			if (ref == &holder) ref = ref->NextRef;
+		RefSet pre_freeze_refs{Refs}; // copy to avoid iterator validity headaches
+		C4Value holder = C4VPropList(this); // add another reference to prevent premature deletion
+		for (C4Value * ref : pre_freeze_refs)
 			ref->SetPropList(this_static);
-		}
 		// store reference
 		if (prop_lists)
-		{
 			prop_lists->push_back(C4VPropList(this_static));
-		}
 		// "this" should be deleted as holder goes out of scope
 	}
 	// Iterate over sorted list of elements to make static
@@ -361,14 +332,12 @@ void C4PropList::Denumerate(C4ValueNumbers * numbers)
 
 C4PropList::~C4PropList()
 {
-	while (FirstRef)
+	for (C4Value * Ref : Refs)
 	{
 		// Manually kill references so DelRef doesn't destroy us again
-		FirstRef->Data = nullptr; FirstRef->Type = C4V_Nil;
-		C4Value *ref = FirstRef;
-		FirstRef = FirstRef->NextRef;
-		ref->NextRef = nullptr;
+		Ref->Data = nullptr; Ref->Type = C4V_Nil;
 	}
+	Refs.clear();
 #ifdef _DEBUG
 	assert(PropLists.Has(this));
 	PropLists.Remove(this);

--- a/src/script/C4PropList.h
+++ b/src/script/C4PropList.h
@@ -30,8 +30,7 @@
 All PropLists can be destroyed while there are still C4Values referencing them, though
 Definitions do not get destroyed during the game. So always check for nullpointers.
 
-The linked list formed by C4PropList::FirstRef and C4Value::NextRef is used to
-change all C4Values referencing the destroyed Proplist to contain nil instead.
+The unordered_set Refs is used to change all C4Values referencing the destroyed Proplist to contain nil instead.
 Objects are also cleaned up via various ClearPointer functions.
 The list is also used as a reference count to remove unused Proplists.
 The exception are C4PropListNumbered and C4Def, which have implicit references
@@ -158,12 +157,13 @@ public:
 
 protected:
 	C4PropList(C4PropList * prototype = nullptr);
-	void ClearRefs() { while (FirstRef) FirstRef->Set0(); }
+	void ClearRefs() { for( C4Value * ref: RefSet{Refs}) ref->Set0(); assert(Refs.empty()); }
 
 private:
 	void AddRef(C4Value *pRef);
-	void DelRef(const C4Value *pRef, C4Value * pNextRef);
-	C4Value *FirstRef{nullptr}; // No-Save
+	void DelRef(C4Value *pRef);
+	typedef std::unordered_set<C4Value *> RefSet;
+	RefSet Refs;
 	C4Set<C4Property> Properties;
 	C4Value prototype;
 	bool constant{false}; // if true, this proplist is not changeable


### PR DESCRIPTION
```js
// Example script
global func Main() {
    var x = Bla(1000 * 12);
    Log("Done");
}

global func Bla(count) {
    if (count < 1)
        return nil;
    count -= 1;
    var x = new Global { i = count };
    var a = Bla(count / 2);
    var b = Bla(count - count / 2);
    x.b = b;
    x.a = a;
    return x;
}
```

The phenomenon occurs depending on whether the order of creating `a` and `b` is the same as assigning them to `x` or not. On some architectures/compiler/os combinations, the problem may also occur randomly, regardless of the order.

Execution times vary between 15 ms and 700 ms without this patch.