### PR TITLE
SDL window init: test availability of AA/subsampling before requiring it

### DIFF
--- a/src/graphics/C4DrawGLMac.mm
+++ b/src/graphics/C4DrawGLMac.mm
@@ -573,7 +573,7 @@ void CStdGLCtx::Clear(bool multisample_change)
 	}
 }
 
-void C4Window::EnumerateMultiSamples(std::vector<int>& samples) const
+void C4Window::EnumerateMultiSamples(std::vector<int>& samples, int) const
 {
 	[C4OpenGLView enumerateMultiSamples:samples];
 }

--- a/src/platform/C4AppT.cpp
+++ b/src/platform/C4AppT.cpp
@@ -102,7 +102,7 @@ bool C4AbstractApp::FlushMessages()
 void C4Window::Clear() {}
 C4Window::C4Window() = default;
 C4Window::~C4Window() = default;
-void C4Window::EnumerateMultiSamples(std::vector<int, std::allocator<int> >&) const  {}
+void C4Window::EnumerateMultiSamples(std::vector<int, std::allocator<int> >&, int) const  {}
 void C4Window::FlashWindow() {}
 void C4Window::GrabMouse(bool) {}
 bool C4Window::GetSize(C4Rect*) {return false;}

--- a/src/platform/C4Window.h
+++ b/src/platform/C4Window.h
@@ -289,7 +289,7 @@ public:
 	virtual bool ReInit(C4AbstractApp* pApp);
 
 	// Creates a list of available samples for multisampling
-	virtual void EnumerateMultiSamples(std::vector<int>& samples) const;
+	virtual void EnumerateMultiSamples(std::vector<int>& samples, int min_expected = 0) const;
 
 	bool StorePosition(const char *szWindowName, const char *szSubKey, bool fStoreSize = true);
 	bool RestorePosition(const char *szWindowName, const char *szSubKey, bool fHidden = false);

--- a/src/platform/C4WindowSDL.cpp
+++ b/src/platform/C4WindowSDL.cpp
@@ -75,7 +75,14 @@ C4Window * C4Window::Init(WindowKind windowKind, C4AbstractApp * pApp, const cha
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, /*REQUESTED_GL_CTX_MINOR*/ 2);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, (Config.Graphics.DebugOpenGL ? SDL_GL_CONTEXT_DEBUG_FLAG : 0));
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-	SetMultisamplingAttributes(Config.Graphics.MultiSampling);
+	std::vector<int> available_samples {};
+	if (Config.Graphics.MultiSampling > 0)
+		EnumerateMultiSamples(available_samples, Config.Graphics.MultiSampling);
+	int samples = 0; // Default to initializing without AA if nothing was available
+	for (auto e : available_samples)
+		if (samples < e && e <= Config.Graphics.MultiSampling)
+			samples = e;
+	SetMultisamplingAttributes(samples);
 	uint32_t flags = SDL_WINDOW_OPENGL;
 	if (windowKind == W_Fullscreen && size->Wdt == -1)
 		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
@@ -87,6 +94,7 @@ C4Window * C4Window::Init(WindowKind windowKind, C4AbstractApp * pApp, const cha
 		Log(SDL_GetError());
 		return nullptr;
 	}
+	Config.Graphics.MultiSampling = samples;
 	SDL_SetWindowData(window, "C4Window", this);
 	Active = true;
 	SDL_ShowCursor(SDL_DISABLE);
@@ -115,10 +123,11 @@ void C4Window::Clear()
 #endif
 }
 
-void C4Window::EnumerateMultiSamples(std::vector<int>& samples) const
+void C4Window::EnumerateMultiSamples(std::vector<int>& samples, int min_expected) const
 {
 	int max_samples;
 	glGetIntegerv(GL_MAX_SAMPLES, &max_samples);
+	max_samples = std::max(max_samples, min_expected);
 	samples.clear();
 	for (int s = 2; s <= max_samples; s *= 2)
 	{

--- a/src/platform/C4WindowWin32.cpp
+++ b/src/platform/C4WindowWin32.cpp
@@ -802,7 +802,7 @@ void C4Window::GrabMouse(bool grab)
 	// TODO
 }
 
-void C4Window::EnumerateMultiSamples(std::vector<int>& samples) const
+void C4Window::EnumerateMultiSamples(std::vector<int>& samples, int) const
 {
 #ifndef USE_CONSOLE
 	if(pGL && pGL->pMainCtx)


### PR DESCRIPTION
No answer in #137 but whatever. It does fix the issue on my machine.