### PR TITLE
Update README with notes for Arch builds

### DIFF
--- a/README
+++ b/README
@@ -41,9 +41,12 @@ system. At least gcc-4.9 is required.
 
 Openclonk build assumes that limits.h will automatically be included.  
 This assumption does not hold on newer versions of GCC.  
-To make the build work, add ```-include /usr/include/c++/13*/limits``` to CXXFLAGS in /etc/makepkg.conf.
+To make the build work, add 
+    -include /usr/include/c++/13*/limits
+to CXXFLAGS in /etc/makepkg.conf.
 
-An example CXXFLAGS line that results in the build working successfully: CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS -include /usr/include/c++/13*/limits"
+An example CXXFLAGS line that results in the build working successfully: 
+    CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS -include /usr/include/c++/13*/limits"
 
 Be aware that this specific change requires GCC v13 to be installed on your system.
 

--- a/README
+++ b/README
@@ -41,7 +41,7 @@ system. At least gcc-4.9 is required.
 
 Openclonk build assumes that limits.h will automatically be included.  
 This assumption does not hold on newer versions of GCC.  
-To make the build work, add `-include /usr/include/c++/13*/limits` to CXXFLAGS in /etc/makepkg.conf.
+To make the build work, add ```-include /usr/include/c++/13*/limits``` to CXXFLAGS in /etc/makepkg.conf.
 
 An example CXXFLAGS line that results in the build working successfully: CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS -include /usr/include/c++/13*/limits"
 

--- a/README
+++ b/README
@@ -39,6 +39,14 @@ to the ones listed above:
 Most distributions should provide these dependencies via their packaging
 system. At least gcc-4.9 is required.
 
+Openclonk build assumes that limits.h will automatically be included.  
+This assumption does not hold on newer versions of GCC.  
+To make the build work, add `-include /usr/include/c++/13*/limits` to CXXFLAGS in /etc/makepkg.conf.
+
+An example CXXFLAGS line that results in the build working successfully: CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS -include /usr/include/c++/13*/limits"
+
+Be aware that this specific change requires GCC v13 to be installed on your system.
+
 Windows Specific
 ================
 In addition to the libraries above, you will need one more if you want to


### PR DESCRIPTION
Fixes issue #163 by making people aware that limits.h not being included automatically is the problem, and giving them a simple and effective fix for that, that will persist for future releases of openclonk.